### PR TITLE
SJRK-191: Add "Storytelling safety & etiquette" section to Story Builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
         <div class="sjrk-st-story-viewer sjrkc-st-story-previewer"></div>
     </div>
 </div>
-
+<div class="sjrk-st-etiquette-container sjrkc-st-etiquette-container"></div>
 <div class="sjrk-st-page-footer-container sjrkc-st-page-footer-container"></div>
 
 <script>

--- a/src/html/storyEdit.html
+++ b/src/html/storyEdit.html
@@ -115,7 +115,7 @@
         <div class="sjrk-st-story-viewer sjrkc-st-story-previewer"></div>
     </div>
 </div>
-
+<div class="sjrk-st-etiquette-container sjrkc-st-etiquette-container"></div>
 <div class="sjrk-st-page-footer-container sjrkc-st-page-footer-container"></div>
 
 <script>

--- a/src/js/storyTelling-page-storyEdit.js
+++ b/src/js/storyTelling-page-storyEdit.js
@@ -72,6 +72,22 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                     }
                 }
             },
+            // the story safety and etiquette notice
+            storyEtiquette: {
+                type: "sjrk.storyTelling.ui",
+                container: ".sjrkc-st-etiquette-container",
+                options: {
+                    components: {
+                        templateManager: {
+                            options: {
+                                templateConfig: {
+                                    templatePath: "%resourcePrefix/src/templates/etiquette.handlebars"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             // the story preview context
             storyPreviewer: {
                 type: "sjrk.storyTelling.ui.storyViewer",

--- a/src/karisma/html/storyEdit.html
+++ b/src/karisma/html/storyEdit.html
@@ -120,7 +120,7 @@
     </div>
     <div class="sjrk-sidebar-right-container sjrkc-sidebar-right-container"></div>
 </div>
-
+<div class="sjrk-st-etiquette-container sjrkc-st-etiquette-container"></div>
 <div class="sjrk-st-page-footer-container sjrkc-st-page-footer-container"></div>
 
 <script>

--- a/src/learningReflections/css/learningReflections.css
+++ b/src/learningReflections/css/learningReflections.css
@@ -6,6 +6,7 @@
     --site-orange: #eec86b;
     --site-grey: #eeeeef;
     --site-dark-grey: #d1d2d4;
+    --site-turquoise: #cbe2e1;
 }
 
 body {
@@ -247,6 +248,23 @@ textarea {
     text-transform: none;
 }
 
+.sjrk-st-etiquette {
+    background: var(--site-turquoise);
+    color: var(--site-blue);
+    padding: 1rem 2rem;
+    font-size: 1rem;
+}
+
+.sjrk-st-etiquette p {
+    font-weight: 800;
+    margin-top: 0;
+}
+
+.sjrk-st-etiquette ul {
+    padding-inline-start: 1.25rem;
+    margin-bottom: 0;
+}
+
 .sjrk-st-page-footer-container {
     font-weight: 300;
     padding: 1rem 3rem;
@@ -283,7 +301,7 @@ textarea {
 }
 
 @media only screen and (max-width: 50em) {
-    .sjrk-st-page-header-container {
+    .sjrk-st-page-header-container, .sjrk-st-etiquette {
         padding: 1rem;
     }
 

--- a/src/learningReflections/html/storyEdit.html
+++ b/src/learningReflections/html/storyEdit.html
@@ -119,7 +119,7 @@
         <div class="sjrk-st-story-viewer sjrkc-st-story-previewer"></div>
     </div>
 </div>
-
+<div class="sjrk-st-etiquette-container sjrkc-st-etiquette-container"></div>
 <div class="sjrk-st-page-footer-container sjrkc-st-page-footer-container"></div>
 
 <script>

--- a/src/messages/storyMessages_en.json
+++ b/src/messages/storyMessages_en.json
@@ -38,6 +38,8 @@
     "message_menu_storyBuilderText": "Story Builder",
     "message_menu_english": "English",
     "message_menu_spanish": "Español",
+    "message_etiquette_title": "Storytelling safety & etiquette",
+    "message_etiquette_body": "* Avoid identifying information such as names and addresses in your story.\n* Don't publish photos or video of other people without their explicit consent.\n* Avoid content that threatens or intimidates any person or suggests violence, hatred or discrimination toward other people.",
     "contentTypes": {
         "audio": "audio",
         "image": "image",

--- a/src/messages/storyMessages_es.json
+++ b/src/messages/storyMessages_es.json
@@ -33,6 +33,8 @@
     "message_menu_storyBuilderText": "Constructor de historias",
     "message_menu_english": "English",
     "message_menu_spanish": "Español",
+    "message_etiquette_title": "Seguridad y etiqueta de las historias",
+    "message_etiquette_body": "* Evite información identificativa como nombres y direcciones en su historia.\n* No publique fotos o videos de otras personas sin su consentimiento explícito.\n* Evite el contenido que amenace o intimide a cualquier persona o sugiera violencia, odio o discriminación hacia otras personas.",
     "contentTypes": {
         "audio": "audio",
         "image": "imagen",

--- a/src/templates/etiquette.handlebars
+++ b/src/templates/etiquette.handlebars
@@ -1,0 +1,4 @@
+<div lang="{{localizedMessages.language}}" class="sjrk-st-etiquette">
+    <p>{{localizedMessages.message_etiquette_title}}</p>
+    {{{md localizedMessages.message_etiquette_body}}}
+</div>

--- a/tests/html/storyTelling-page-storyEdit-Tests.html
+++ b/tests/html/storyTelling-page-storyEdit-Tests.html
@@ -66,6 +66,7 @@
             <div id="testMenu"></div>
             <div id="testStoryEditor"></div>
             <div id="testStoryPreviewer" class="sjrkc-st-story-previewer"></div>
+            <div id="testStoryEtiquette"></div>
         </div>
 
         <div class="sjrk-prefsEditor-container">

--- a/tests/js/storyTelling-page-storyEditTests.js
+++ b/tests/js/storyTelling-page-storyEditTests.js
@@ -26,6 +26,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             menu: {
                 container: "#testMenu"
             },
+            storyEtiquette: {
+                container: "#testStoryEtiquette"
+            },
             storyEditor: {
                 container: "#testStoryEditor",
                 options: {


### PR DESCRIPTION
Adds the "Storytelling safety & etiquette" notice to the Story Builder (edit page).

Requires update to server project, PR filed to allow this: https://github.com/fluid-project/sjrk-story-telling-server/pull/6