### PR TITLE
SJRK-202: Update the example story

### DIFF
--- a/src/templates/storyBlockTextView.handlebars
+++ b/src/templates/storyBlockTextView.handlebars
@@ -1,7 +1,7 @@
 {{#with dynamicValues}}
     <div class="sjrk-st-block" lang="{{language}}">
         <h3 class="sjrk-st-block-heading-view">{{heading}}</h3>
-        <p class="sjrk-st-block-text-view">{{text}}</p>
+        <div class="sjrk-st-block-text-view">{{{md text}}}</div>
         <p class="sjrk-st-block-text-view">{{simplifiedText}}</p>
     </div>
 {{/with}}


### PR DESCRIPTION
Updates the text block view template to allow for the rich formatting present in the new example story. Text blocks now support Markdown via the GPII Handlebars `md` helper.

This project has accompanying changes on the server side: https://github.com/fluid-project/sjrk-story-telling-server/pull/10