### PR TITLE
SJRK-240: excluding test dirs from .dockerignore to serve browser tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 node_modules
 tests
+!tests/binaries
+!tests/ui
 npm-debug.log
 .git
 .gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ deleted_uploads/*
 !deleted_uploads/.gitkeep
 secrets.json
 couchdb
+.vscode/*


### PR DESCRIPTION
Browser test files were not being served because the `tests` dir was listed in the .dockerignore file. I added exceptions for `tests\ui` and `tests\binaries` to make sure those two directories are copied up to the web app container.