### PR TITLE
SJRK-227: Added logging invoker and listeners for all datasource.onError

### DIFF
--- a/server/src/js/dataSource.js
+++ b/server/src/js/dataSource.js
@@ -20,6 +20,16 @@ fluid.defaults("sjrk.storyTelling.server.dataSource.couch.base", {
         getURL: {
             funcName: "sjrk.storyTelling.server.dataSource.couch.base.getURL",
             args: ["{that}.options.host", "{that}.options.path"]
+        },
+        logDataSourceError: {
+            funcName: "fluid.log",
+            args: [fluid.logLevel.WARN, "Datasource error: ", "{arguments}.0"]
+        }
+    },
+    listeners: {
+        "onError.logDataSourceError": {
+            func: "{that}.logDataSourceError",
+            args: ["{arguments}.0"]
         }
     }
 });

--- a/server/src/js/dataSource.js
+++ b/server/src/js/dataSource.js
@@ -20,16 +20,12 @@ fluid.defaults("sjrk.storyTelling.server.dataSource.couch.base", {
         getURL: {
             funcName: "sjrk.storyTelling.server.dataSource.couch.base.getURL",
             args: ["{that}.options.host", "{that}.options.path"]
-        },
-        logDataSourceError: {
-            funcName: "fluid.log",
-            args: [fluid.logLevel.WARN, "Datasource error: ", "{arguments}.0"]
         }
     },
     listeners: {
         "onError.logDataSourceError": {
-            func: "{that}.logDataSourceError",
-            args: ["{arguments}.0"]
+            funcName: "fluid.log",
+            args: [fluid.logLevel.WARN, "Couch DataSource error: ", "{arguments}.0"]
         }
     }
 });

--- a/server/src/js/serverSetup.js
+++ b/server/src/js/serverSetup.js
@@ -27,12 +27,6 @@ fluid.defaults("sjrk.storyTelling.server", {
                     savingEnabled: true
                 },
                 port: 8081,
-                invokers: {
-                    logDataSourceError: {
-                        funcName: "fluid.log",
-                        args: [fluid.logLevel.WARN, "Datasource error in ", "{arguments}.0", "{arguments}.1"]
-                    }
-                },
                 components: {
                     viewDataSource: {
                         type: "sjrk.storyTelling.server.dataSource.couch.view",
@@ -40,12 +34,6 @@ fluid.defaults("sjrk.storyTelling.server", {
                             distributeOptions: {
                                 target: "{that}.options.host",
                                 record: "@expand:kettle.resolvers.env(COUCHDB_URL)"
-                            },
-                            listeners: {
-                                "onError.logDataSourceError": {
-                                    func: "{server}.logDataSourceError",
-                                    args: ["viewDataSource: ", "{arguments}.0"]
-                                }
                             }
                         }
                     },
@@ -55,12 +43,6 @@ fluid.defaults("sjrk.storyTelling.server", {
                             distributeOptions: {
                                 target: "{that}.options.host",
                                 record: "@expand:kettle.resolvers.env(COUCHDB_URL)"
-                            },
-                            listeners: {
-                                "onError.logDataSourceError": {
-                                    func: "{server}.logDataSourceError",
-                                    args: ["storyDataSource: ", "{arguments}.0"]
-                                }
                             }
                         }
                     },
@@ -70,12 +52,6 @@ fluid.defaults("sjrk.storyTelling.server", {
                             distributeOptions: {
                                 target: "{that}.options.host",
                                 record: "@expand:kettle.resolvers.env(COUCHDB_URL)"
-                            },
-                            listeners: {
-                                "onError.logDataSourceError": {
-                                    func: "{server}.logDataSourceError",
-                                    args: ["deleteStoryDataSource: ", "{arguments}.0"]
-                                }
                             }
                         }
                     },

--- a/server/src/js/serverSetup.js
+++ b/server/src/js/serverSetup.js
@@ -27,6 +27,12 @@ fluid.defaults("sjrk.storyTelling.server", {
                     savingEnabled: true
                 },
                 port: 8081,
+                invokers: {
+                    logDataSourceError: {
+                        funcName: "fluid.log",
+                        args: [fluid.logLevel.WARN, "Datasource error in ", "{arguments}.0", "{arguments}.1"]
+                    }
+                },
                 components: {
                     viewDataSource: {
                         type: "sjrk.storyTelling.server.dataSource.couch.view",
@@ -34,6 +40,12 @@ fluid.defaults("sjrk.storyTelling.server", {
                             distributeOptions: {
                                 target: "{that}.options.host",
                                 record: "@expand:kettle.resolvers.env(COUCHDB_URL)"
+                            },
+                            listeners: {
+                                "onError.logDataSourceError": {
+                                    func: "{server}.logDataSourceError",
+                                    args: ["viewDataSource: ", "{arguments}.0"]
+                                }
                             }
                         }
                     },
@@ -43,6 +55,12 @@ fluid.defaults("sjrk.storyTelling.server", {
                             distributeOptions: {
                                 target: "{that}.options.host",
                                 record: "@expand:kettle.resolvers.env(COUCHDB_URL)"
+                            },
+                            listeners: {
+                                "onError.logDataSourceError": {
+                                    func: "{server}.logDataSourceError",
+                                    args: ["storyDataSource: ", "{arguments}.0"]
+                                }
                             }
                         }
                     },
@@ -52,6 +70,12 @@ fluid.defaults("sjrk.storyTelling.server", {
                             distributeOptions: {
                                 target: "{that}.options.host",
                                 record: "@expand:kettle.resolvers.env(COUCHDB_URL)"
+                            },
+                            listeners: {
+                                "onError.logDataSourceError": {
+                                    func: "{server}.logDataSourceError",
+                                    args: ["deleteStoryDataSource: ", "{arguments}.0"]
+                                }
                             }
                         }
                     },


### PR DESCRIPTION
This pull request does not include integration tests as I was unable to determine how to listen for the fluid.loggingEvent being fired once fluid.log was called from the test server.