### PR TITLE
SJRK-253: removed context awareness and mobile capture functionality

### DIFF
--- a/docs/grades-ui.md
+++ b/docs/grades-ui.md
@@ -37,15 +37,12 @@
 * `sjrk.storyTelling.blockUi.timeBased` provides common shared controls related to playback of audio and video blocks
   and is used for both viewing and editing.
 * `sjrk.storyTelling.blockUi.editor` is for editing a block, providing the common elements for the various individual
-  editor types. This file also contains some basic configuration to enable the detection of cameras on mobile devices,
-  with specific implementations being handled by the particular editor grades. The `editor` grades are:
+  editor types. The `editor` grades are:
   * `sjrk.storyTelling.blockUi.editor.textBlockEditor` for text blocks
-  * `sjrk.storyTelling.blockUi.editor.imageBlockEditor` for image blocks. This grade also has some additional
-      configuration which uses context awareness to determine whether to load a slightly different editor that can
-      capture from a camera.
+  * `sjrk.storyTelling.blockUi.editor.imageBlockEditor` for image blocks
   * `sjrk.storyTelling.blockUi.editor.mediaBlockEditor` for time-based media types:
     * `sjrk.storyTelling.blockUi.editor.audioBlockEditor` for audio blocks
-  * `sjrk.storyTelling.blockUi.editor.videoBlockEditor` for video blocks. Also contains mobile camera detection
+  * `sjrk.storyTelling.blockUi.editor.videoBlockEditor` for video blocks
 
 ## User interfaces and Pages
 

--- a/src/ui/blockUi-editor-imageBlockEditor.js
+++ b/src/ui/blockUi-editor-imageBlockEditor.js
@@ -12,18 +12,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
 (function ($, fluid) {
 
     // an editing interface for individual image-type blocks
-    // provides additional capabilities depending on whether the device has a camera
     fluid.defaults("sjrk.storyTelling.blockUi.editor.imageBlockEditor", {
-        gradeNames: ["sjrk.storyTelling.mobileCameraAware", "sjrk.storyTelling.blockUi.editor"],
-        contextAwareness: {
-            technology: {
-                checks: {
-                    mobileCamera: {
-                        gradeNames: "sjrk.storyTelling.blockUi.editor.imageBlockEditor.hasMobileCamera"
-                    }
-                }
-            }
-        },
+        gradeNames: ["sjrk.storyTelling.blockUi.editor"],
         selectors: {
             imagePreview: ".sjrkc-st-block-media-preview",
             imageUploadButton: ".sjrkc-st-block-media-upload-button",
@@ -108,62 +98,6 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                             args: "{that}.model.fileObjectURL",
                             excludeSource: "init"
                         }
-                    }
-                }
-            }
-        }
-    });
-
-    // the extra interface elements to be added if the device has a camera
-    fluid.defaults("sjrk.storyTelling.blockUi.editor.imageBlockEditor.hasMobileCamera", {
-        selectors: {
-            imageCaptureButton: ".sjrkc-st-block-media-capture-button",
-            cameraCaptureUploader: ".sjrkc-st-block-camera-capture-input"
-        },
-        events: {
-            imageCaptureRequested: null
-        },
-        listeners: {
-            "{templateManager}.events.onTemplateRendered": {
-                this: "{that}.dom.imageCaptureButton",
-                method: "click",
-                args: ["{that}.events.imageCaptureRequested.fire"],
-                namespace: "bindImageCaptureRequested"
-            }
-        },
-        components: {
-            // captures an image from the device, previews it and uploads it
-            cameraCaptureUploader: {
-                type: "sjrk.storyTelling.block.singleFileUploader",
-                createOnEvent: "{templateManager}.events.onTemplateRendered",
-                container: "{hasMobileCamera}.dom.cameraCaptureUploader",
-                options: {
-                    selectors: {
-                        fileInput: "{that}.container"
-                    },
-                    model: {
-                        fileObjectURL: "{imageBlock}.model.imageUrl",
-                        fileDetails: "{imageBlock}.model.fileDetails"
-                    },
-                    listeners: {
-                        "{hasMobileCamera}.events.imageCaptureRequested": {
-                            func: "{that}.events.onUploadRequested.fire",
-                            namespace: "fireUploadForImageCapture"
-                        }
-                    },
-                    modelListeners: {
-                        "fileObjectURL": {
-                            func: "{imageBlockEditor}.updateImagePreview",
-                            args: "{that}.model.fileObjectURL",
-                            excludeSource: "init"
-                        }
-                    }
-                }
-            },
-            block: {
-                options: {
-                    model: {
-                        hasMobileCamera: true
                     }
                 }
             }

--- a/src/ui/blockUi-editor-videoBlockEditor.js
+++ b/src/ui/blockUi-editor-videoBlockEditor.js
@@ -12,18 +12,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
 (function ($, fluid) {
 
     // an editing interface for individual video-type blocks
-    // provides additional capabilities depending on whether the device has a camera
     fluid.defaults("sjrk.storyTelling.blockUi.editor.videoBlockEditor", {
-        gradeNames: ["sjrk.storyTelling.mobileCameraAware", "sjrk.storyTelling.blockUi.editor", "sjrk.storyTelling.blockUi.timeBased"],
-        contextAwareness: {
-            technology: {
-                checks: {
-                    mobileCamera: {
-                        gradeNames: "sjrk.storyTelling.blockUi.editor.videoBlockEditor.hasMobileCamera"
-                    }
-                }
-            }
-        },
+        gradeNames: ["sjrk.storyTelling.blockUi.editor", "sjrk.storyTelling.blockUi.timeBased"],
         selectors: {
             videoUploadButton: ".sjrkc-st-block-media-upload-button",
             singleFileUploader: ".sjrkc-st-block-uploader-input"
@@ -95,62 +85,6 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                             args: "{that}.model.fileObjectURL",
                             excludeSource: "init"
                         }
-                    }
-                }
-            }
-        }
-    });
-
-    // the extra interface elements to be added if the device has a camera
-    fluid.defaults("sjrk.storyTelling.blockUi.editor.videoBlockEditor.hasMobileCamera", {
-        selectors: {
-            videoCaptureButton: ".sjrkc-st-block-media-capture-button",
-            cameraCaptureUploader: ".sjrkc-st-block-camera-capture-input"
-        },
-        events: {
-            videoCaptureRequested: null
-        },
-        listeners: {
-            "{templateManager}.events.onTemplateRendered": {
-                this: "{that}.dom.videoCaptureButton",
-                method: "click",
-                args: ["{that}.events.videoCaptureRequested.fire"],
-                namespace: "bindVideoCaptureRequested"
-            }
-        },
-        components: {
-            // captures an video from the device, previews it and uploads it
-            cameraCaptureUploader: {
-                type: "sjrk.storyTelling.block.singleFileUploader",
-                createOnEvent: "{templateManager}.events.onTemplateRendered",
-                container: "{hasMobileCamera}.dom.cameraCaptureUploader",
-                options: {
-                    selectors: {
-                        fileInput: "{that}.container"
-                    },
-                    model: {
-                        fileObjectURL: "{videoBlock}.model.mediaUrl",
-                        fileDetails: "{videoBlock}.model.fileDetails"
-                    },
-                    listeners: {
-                        "{hasMobileCamera}.events.videoCaptureRequested": {
-                            func: "{that}.events.onUploadRequested.fire",
-                            namespace: "fireUploadForVideoCapture"
-                        }
-                    },
-                    modelListeners: {
-                        "fileObjectURL": {
-                            func: "{videoBlockEditor}.updateMediaPlayer",
-                            args: "{that}.model.fileObjectURL",
-                            excludeSource: "init"
-                        }
-                    }
-                }
-            },
-            block: {
-                options: {
-                    model: {
-                        hasMobileCamera: true
                     }
                 }
             }

--- a/src/ui/blockUi-editor.js
+++ b/src/ui/blockUi-editor.js
@@ -5,7 +5,7 @@ You may obtain a copy of the BSD License at
 https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENSE.txt
 */
 
-/* global fluid, sjrk */
+/* global fluid */
 
 "use strict";
 
@@ -35,38 +35,6 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                     }
                 }
             }
-        }
-    });
-
-    // Grade used to detect and enhance if a mobile camera is available
-    // May not be super-reliable at this time
-    // Assumes anything on iPhone, iPad or Android is a mobile
-    // device with a camera
-    fluid.defaults("sjrk.storyTelling.mobileCameraAware", {
-        gradeNames: ["fluid.contextAware", "fluid.component"],
-        contextAwareness: {
-            technology: {
-                checks: {
-                    mobileCamera: {
-                        contextValue: "{fluid.platform.hasMobileCamera}"
-                        // gradeNames: supplied by implementation
-                    }
-                    // defaultGradeNames: supplied by implementation
-                }
-            }
-        }
-    });
-
-    /* Determines whether the current user device has a "mobile" camera. */
-    sjrk.storyTelling.mobileCameraAware.hasMobileCamera = function () {
-        var userAgent = navigator.userAgent.toLowerCase();
-        var hasMobileCamera = userAgent.includes("iphone") || userAgent.includes("ipad") || userAgent.includes("android");
-        return hasMobileCamera;
-    };
-
-    fluid.contextAware.makeChecks({
-        "fluid.platform.hasMobileCamera": {
-            funcName: "sjrk.storyTelling.mobileCameraAware.hasMobileCamera"
         }
     });
 

--- a/tests/ui/html/blockUi-editor-imageBlockEditor-Tests.html
+++ b/tests/ui/html/blockUi-editor-imageBlockEditor-Tests.html
@@ -42,10 +42,6 @@
 
         <title>Image Block Editor - Tests</title>
         <style>
-            .sjrk-st-block-uploader-container, .sjrk-st-block-camera-capture-container {
-                display: none;
-            }
-
             .sjrk-st-block-media-preview-container {
                 width: 10em;
             }

--- a/tests/ui/html/blockUi-editor-imageBlockEditor-manual-Tests.html
+++ b/tests/ui/html/blockUi-editor-imageBlockEditor-manual-Tests.html
@@ -42,10 +42,6 @@
 
         <title>Image Block Editor - Tests</title>
         <style>
-            .sjrk-st-block-uploader-container, .sjrk-st-block-camera-capture-container {
-                display: none;
-            }
-
             .sjrk-st-block-media-preview-container {
                 width: 10em;
             }

--- a/tests/ui/html/blockUi-editor-videoBlockEditor-Tests.html
+++ b/tests/ui/html/blockUi-editor-videoBlockEditor-Tests.html
@@ -44,10 +44,6 @@
 
         <title>Video Block Editor - Tests</title>
         <style>
-            .sjrk-st-block-uploader-container, .sjrk-st-block-camera-capture-container {
-                display: none;
-            }
-
             .sjrk-st-block-media-preview-container {
                 width: 20em;
             }

--- a/tests/ui/html/blockUi-editor-videoBlockEditor-manual-Tests.html
+++ b/tests/ui/html/blockUi-editor-videoBlockEditor-manual-Tests.html
@@ -44,10 +44,6 @@
 
         <title>Video Block Editor - Tests</title>
         <style>
-            .sjrk-st-block-uploader-container, .sjrk-st-block-camera-capture-container {
-                display: none;
-            }
-
             .sjrk-st-block-media-preview-container {
                 width: 20em;
             }

--- a/tests/ui/js/blockUi-editor-imageBlockEditorTests.js
+++ b/tests/ui/js/blockUi-editor-imageBlockEditorTests.js
@@ -30,7 +30,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             name: "Test Image Block Editor.",
             tests: [{
                 name: "Test Image Block Editor",
-                expect: 5,
+                expect: 4,
                 sequence: [{
                     event: "{imageBlockEditorTest imageBlockEditor binder}.events.onUiReadyToBind",
                     listener: "jqUnit.assert",
@@ -64,15 +64,6 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                     event: "{imageBlockEditor}.events.onImageUploadRequested",
                     listener: "jqUnit.assert",
                     args: ["The imageUploadButton event fired"]
-                },
-                {
-                    jQueryTrigger: "click",
-                    element: "{imageBlockEditor}.dom.imageCaptureButton"
-                },
-                {
-                    event: "{imageBlockEditor}.events.imageCaptureRequested",
-                    listener: "jqUnit.assert",
-                    args: ["The imageCaptureRequested event fired"]
                 }]
             }]
         }]

--- a/tests/ui/js/blockUi-editor-videoBlockEditorTests.js
+++ b/tests/ui/js/blockUi-editor-videoBlockEditorTests.js
@@ -30,7 +30,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             name: "Test Video Block Editor.",
             tests: [{
                 name: "Test Video Block Editor",
-                expect: 6,
+                expect: 5,
                 sequence: [{
                     event: "{videoBlockEditorTest videoBlockEditor binder}.events.onUiReadyToBind",
                     listener: "jqUnit.assert",
@@ -74,15 +74,6 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                     event: "{videoBlockEditor}.events.onVideoUploadRequested",
                     listener: "jqUnit.assert",
                     args: ["The videoUploadButton event fired"]
-                },
-                {
-                    jQueryTrigger: "click",
-                    element: "{videoBlockEditor}.dom.videoCaptureButton"
-                },
-                {
-                    event: "{videoBlockEditor}.events.videoCaptureRequested",
-                    listener: "jqUnit.assert",
-                    args: ["The videoCaptureRequested event fired"]
                 }]
             }]
         }]

--- a/tests/ui/js/testUtils.js
+++ b/tests/ui/js/testUtils.js
@@ -170,20 +170,6 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         jqUnit.assertEquals("Number of remaining blocks is expected #: " + expectedNumberOfBlocks, expectedNumberOfBlocks, managedComponentRegistryAsArray.length);
     };
 
-    /* Returns true in order to force the hasMobileCamera grade to be merged in
-     * when it is applicable
-     */
-    sjrk.storyTelling.testUtils.forceMobileCamera = function () {
-        return true;
-    };
-
-    /* Using the function defined above, overrides the camera capture checking */
-    fluid.contextAware.makeChecks({
-        "fluid.platform.hasMobileCamera": {
-            funcName: "sjrk.storyTelling.testUtils.forceMobileCamera"
-        }
-    });
-
     /* A simple function that asserts that it was called with a truthy value,
      * intended for use as a callback
      * - "value": a value (hopefully truthy)

--- a/themes/base/css/storyTelling.css
+++ b/themes/base/css/storyTelling.css
@@ -217,7 +217,7 @@ fieldset ul {
     margin: 0;
 }
 
-.sjrk-st-block-uploader-container, .sjrk-st-block-camera-capture-container {
+.sjrk-st-block-uploader-container {
     display: none;
 }
 

--- a/themes/base/messages/storyBlockMessages_en.json
+++ b/themes/base/messages/storyBlockMessages_en.json
@@ -14,9 +14,6 @@
     "message_uploadButtonAudio": "Upload audio",
     "message_uploadButtonImage": "Upload image",
     "message_uploadButtonVideo": "Upload video",
-    "message_captureButtonAudio": "Capture audio",
-    "message_captureButtonImage": "Capture image",
-    "message_captureButtonVideo": "Capture video",
     "message_transcriptInputLabel": "Transcript",
     "message_transcriptInputPlaceholder": "Add transcript"
 }

--- a/themes/base/messages/storyBlockMessages_es.json
+++ b/themes/base/messages/storyBlockMessages_es.json
@@ -14,9 +14,6 @@
     "message_uploadButtonAudio": "Cargar audio",
     "message_uploadButtonImage": "Cargar imagen",
     "message_uploadButtonVideo": "Cargar video",
-    "message_captureButtonAudio": "Capturar audio",
-    "message_captureButtonImage": "Capturar imagen",
-    "message_captureButtonVideo": "Capturar video",
     "message_transcriptInputLabel": "Transcripción",
     "message_transcriptInputPlaceholder": "Crear opción de texto"
 }

--- a/themes/base/messages/storyBlockMessages_pt.json
+++ b/themes/base/messages/storyBlockMessages_pt.json
@@ -10,6 +10,5 @@
     "message_altTextInputPlaceholder": "Adicione o texto alternativo aqui",
     "message_descriptionInputLabel": "Descrição",
     "message_descriptionInputPlaceholder": "Digite a legenda aqui",
-    "message_uploadButton": "Adicionar",
-    "message_captureButton": "Capturar"
+    "message_uploadButton": "Adicionar"
 }

--- a/themes/base/templates/storyBlockMediaEdit.handlebars
+++ b/themes/base/templates/storyBlockMediaEdit.handlebars
@@ -31,15 +31,6 @@
             {{#equals dynamicValues.blockType "video"}}
                 <button type="button" class="sjrkc-st-block-media-upload-button sjrk-st-block-media-upload-button">{{localizedMessages.message_uploadButtonVideo}}</button>
             {{/equals}}
-
-            {{#if dynamicValues.hasMobileCamera}}
-                {{#equals dynamicValues.blockType "image"}}
-                    <button type="button" class="sjrkc-st-block-media-capture-button sjrk-st-block-media-capture-button">{{localizedMessages.message_captureButtonImage}}</button>
-                {{/equals}}
-                {{#equals dynamicValues.blockType "video"}}
-                    <button type="button" class="sjrkc-st-block-media-capture-button sjrk-st-block-media-capture-button">{{localizedMessages.message_captureButtonVideo}}</button>
-                {{/equals}}
-            {{/if}}
         </div>
 
         {{#getIds "storyBlockHeading"}}
@@ -92,12 +83,6 @@
         <div class="sjrkc-st-block-uploader-container sjrk-st-block-uploader-container">
             <input name="file" type="file" accept="{{dynamicValues.blockType}}/*" class="sjrkc-st-block-uploader-input sjrk-st-block-uploader-input" />
         </div>
-        {{#if dynamicValues.hasMobileCamera}}
-            <!-- Container for the camera capture -->
-            <div class="sjrkc-st-block-camera-capture-container sjrk-st-block-camera-capture-container">
-                <input name="file" type="file" accept="{{dynamicValues.blockType}}/*" capture="camera" class="sjrkc-st-block-camera-capture-input sjrk-st-block-camera-capture-input" />
-            </div>
-        {{/if}}
 
     </form>
 </div>

--- a/themes/learningReflections/css/learningReflections.css
+++ b/themes/learningReflections/css/learningReflections.css
@@ -318,8 +318,7 @@ h3:empty {
     border-right: none;
 }
 
-.sjrk-st-block-media-upload-button,
-.sjrk-st-block-media-capture-button {
+.sjrk-st-block-media-upload-button {
     background: var(--site-dark-grey);
     border: none;
     font-size: 1rem;


### PR DESCRIPTION
Removes a number of grades, tests and markup bits that provided extra buttons for capturing photos and videos on mobile devices (based on a very fragile check).

Removed:
	- sjrk.storyTelling.blockUi.editor.imageBlockEditor.hasMobileCamera
	- sjrk.storyTelling.blockUi.editor.videoBlockEditor.hasMobileCamera
	- sjrk.storyTelling.mobileCameraAware
	- sjrk.storyTelling.mobileCameraAware.hasMobileCamera
	- sjrk.storyTelling.testUtils.forceMobileCamera
	- Bits of storyBlockMediaEdit.handlebars that refer to hasMobileCamera
	- Test in sjrk.storyTelling.blockUi.editor.imageBlockEditorTester
	- Test in sjrk.storyTelling.blockUi.editor.videoBlockEditorTester

@cindyli to review :)