### PR TITLE
SJRK-263: Empty blocks are being saved by storySpeaker

### DIFF
--- a/src/ui/base-page-storyEdit.js
+++ b/src/ui/base-page-storyEdit.js
@@ -78,16 +78,6 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             "audio": ["mediaUrl"],
             "video": ["mediaUrl"]
         },
-        modelRelay: {
-            editorStoryToPreviewer: {
-                target: "{storyPreviewer}.story.model",
-                singleTransform: {
-                    type: "fluid.transforms.free",
-                    func: "sjrk.storyTelling.base.page.storyEdit.removeEmptyBlocks",
-                    args: ["{storyEditor}.story.model", "{that}.options.blockContentValues"]
-                }
-            }
-        },
         components: {
             storySpeaker: {
                 options: {
@@ -215,6 +205,21 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                                     }
                                 }
                             }
+                        },
+                        story: {
+                            options: {
+                                model: "{storyEditor}.story.model",
+                                modelRelay: {
+                                    contentEmptyBlockFilter: {
+                                        target: "content",
+                                        singleTransform: {
+                                            type: "fluid.transforms.free",
+                                            func: "sjrk.storyTelling.base.page.storyEdit.removeEmptyBlocks",
+                                            args: ["{storyPreviewer}.story.model.content", "{storyEdit}.options.blockContentValues"]
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -222,24 +227,25 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         }
     });
 
-    /* Removes all empty blocks from a given array of story blocks
-     * - "blocks": an array of story blocks
-     * - "blockContentValues": a collection of arrays which outline the values
+    /* Removes all empty blocks from a given collection of story blocks
+     * - "blocks": a collection of story blocks (sjrk.storyTelling.block)
+     * - "blockContentValues": a hash map of block types which outlines the values
      *      that, if at least one is truthy, means a particular block is not empty
      */
-    sjrk.storyTelling.base.page.storyEdit.removeEmptyBlocks = function (storyModel, blockContentValues) {
-        storyModel.content = fluid.remove_if(storyModel.content, function (block) {
+    sjrk.storyTelling.base.page.storyEdit.removeEmptyBlocks = function (blocks, blockContentValues) {
+        var filteredBlocks = fluid.remove_if(blocks, function (block) {
             return sjrk.storyTelling.base.page.storyEdit.isEmptyBlock(block, blockContentValues[block.blockType]);
         });
 
-        return storyModel;
+        return filteredBlocks;
     };
 
     /* Returns true if a block is determined to be empty, based on the values
      * listed in blockContentValues. If at least one of those values is truthy,
      * the block is not empty.
-     * - "block": a story block
-     * - "blockContentValues": an array of the values as described above
+     * - "block": a single story block (sjrk.storyTelling.block)
+     * - "blockContentValues": a hash map of block types which outlines the values
+     *      that, if at least one is truthy, means a particular block is not empty
      */
     sjrk.storyTelling.base.page.storyEdit.isEmptyBlock = function (block, blockContentValues) {
         return !fluid.find_if(blockContentValues, function (blockContentValues) {

--- a/src/ui/base-page-storyEdit.js
+++ b/src/ui/base-page-storyEdit.js
@@ -56,7 +56,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             },
             "onStoryShareRequested.submitStory": {
                 funcName: "sjrk.storyTelling.base.page.storyEdit.submitStory",
-                args: ["{storyEditor}", "{that}.events.onStoryShareComplete"]
+                args: ["{storyPreviewer}", "{that}.events.onStoryShareComplete"]
             },
             "onCreate.setEditorDisplay": {
                 func: "{that}.setEditorDisplay"

--- a/src/ui/base-page-storyEdit.js
+++ b/src/ui/base-page-storyEdit.js
@@ -245,15 +245,16 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     };
 
     /* Returns true if a block is determined to be empty, based on the values
-     * listed in blockContentValues. If at least one of those values is truthy,
-     * the block is not empty.
+     * listed in blockContentValuesForType. If at least one of those values is
+     * truthy, the block is not empty. If the values are empty or otherwise can't
+     * be iterated over, then the block is also empty regardless of its contents.
      * - "block": a single story block (sjrk.storyTelling.block)
-     * - "blockContentValues": a hash map of block types which outlines the values
-     *      that, if at least one is truthy, means a particular block is not empty
+     * - "blockContentValuesForType": an array of values for the block's type
+     *      that, if at least one is truthy, mean the block is not empty
      */
-    sjrk.storyTelling.base.page.storyEdit.isEmptyBlock = function (block, blockContentValues) {
-        return !fluid.find_if(blockContentValues, function (blockContentValues) {
-            return !!block[blockContentValues];
+    sjrk.storyTelling.base.page.storyEdit.isEmptyBlock = function (block, blockContentValuesForType) {
+        return !fluid.find_if(blockContentValuesForType, function (blockContentValue) {
+            return !!block[blockContentValue];
         });
     };
 

--- a/src/ui/base-page-storyEdit.js
+++ b/src/ui/base-page-storyEdit.js
@@ -233,8 +233,12 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
      *      that, if at least one is truthy, means a particular block is not empty
      */
     sjrk.storyTelling.base.page.storyEdit.removeEmptyBlocks = function (blocks, blockContentValues) {
-        var filteredBlocks = fluid.remove_if(blocks, function (block) {
-            return sjrk.storyTelling.base.page.storyEdit.isEmptyBlock(block, blockContentValues[block.blockType]);
+        var filteredBlocks = [];
+
+        fluid.each(blocks, function (block) {
+            if (!sjrk.storyTelling.base.page.storyEdit.isEmptyBlock(block, blockContentValues[block.blockType])) {
+              filteredBlocks.push(block);
+            }
         });
 
         return filteredBlocks;

--- a/src/ui/base-page-storyEdit.js
+++ b/src/ui/base-page-storyEdit.js
@@ -56,7 +56,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             },
             "onStoryShareRequested.submitStory": {
                 funcName: "sjrk.storyTelling.base.page.storyEdit.submitStory",
-                args: ["{storyEditor}", "{storyPreviewer}.story.model", "{that}.events.onStoryShareComplete"]
+                args: ["{storyEditor}.dom.storyEditorForm", "{storyPreviewer}.story.model", "{that}.events.onStoryShareComplete"]
             },
             "onCreate.setEditorDisplay": {
                 func: "{that}.setEditorDisplay"
@@ -237,7 +237,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
 
         fluid.each(blocks, function (block) {
             if (!sjrk.storyTelling.base.page.storyEdit.isEmptyBlock(block, blockContentValues[block.blockType])) {
-              filteredBlocks.push(block);
+                filteredBlocks.push(block);
             }
         });
 
@@ -262,16 +262,14 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         $(pageContainer).toggleClass(hiddenEditorClass, !authoringEnabled);
     };
 
-    sjrk.storyTelling.base.page.storyEdit.submitStory = function (storyEditor, storyModel, errorEvent) {
-        var form = storyEditor.container.find("form");
-
-        form.attr("action", "/stories/");
-        form.attr("method", "post");
-        form.attr("enctype", "multipart/form-data");
+    sjrk.storyTelling.base.page.storyEdit.submitStory = function (storyEditorForm, storyModel, errorEvent) {
+        storyEditorForm.attr("action", "/stories/");
+        storyEditorForm.attr("method", "post");
+        storyEditorForm.attr("enctype", "multipart/form-data");
 
         // This is the easiest way to be able to submit form
         // content in the background via ajax
-        var formData = new FormData(form[0]);
+        var formData = new FormData(storyEditorForm[0]);
 
         // Stores the entire model as a JSON string in one
         // field of the multipart form
@@ -282,8 +280,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         // proper handling of feedback on success / failure,
         // but currently it just logs to console
         $.ajax({
-            url         : form.attr("action"),
-            data        : formData ? formData : form.serialize(),
+            url         : storyEditorForm.attr("action"),
+            data        : formData || storyEditorForm.serialize(),
             cache       : false,
             contentType : false,
             processData : false,
@@ -297,11 +295,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             error       : function (jqXHR, textStatus, errorThrown) {
                 fluid.log("Something went wrong");
                 fluid.log(jqXHR, textStatus, errorThrown);
-                var errorMessage = "Internal server error";
-                if (jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.message) {
-                    errorMessage = jqXHR.responseJSON.message;
-                }
-                errorEvent.fire(errorMessage);
+
+                errorEvent.fire(fluid.get(jqXHR, ["responseJSON", "message"]) || "Internal server error");
             }
         });
     };

--- a/src/ui/base-page-storyEdit.js
+++ b/src/ui/base-page-storyEdit.js
@@ -56,7 +56,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             },
             "onStoryShareRequested.submitStory": {
                 funcName: "sjrk.storyTelling.base.page.storyEdit.submitStory",
-                args: ["{storyPreviewer}", "{that}.events.onStoryShareComplete"]
+                args: ["{storyEditor}", "{storyPreviewer}.story.model", "{that}.events.onStoryShareComplete"]
             },
             "onCreate.setEditorDisplay": {
                 func: "{that}.setEditorDisplay"
@@ -258,8 +258,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         $(pageContainer).toggleClass(hiddenEditorClass, !authoringEnabled);
     };
 
-    sjrk.storyTelling.base.page.storyEdit.submitStory = function (that, errorEvent) {
-        var form = that.container.find("form");
+    sjrk.storyTelling.base.page.storyEdit.submitStory = function (storyEditor, storyModel, errorEvent) {
+        var form = storyEditor.container.find("form");
 
         form.attr("action", "/stories/");
         form.attr("method", "post");
@@ -271,7 +271,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
 
         // Stores the entire model as a JSON string in one
         // field of the multipart form
-        var modelAsJSON = JSON.stringify(that.story.model);
+        var modelAsJSON = JSON.stringify(storyModel);
         formData.append("model", modelAsJSON);
 
         // In the real implementation, this should have

--- a/src/ui/base-page-storyEdit.js
+++ b/src/ui/base-page-storyEdit.js
@@ -264,9 +264,11 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     };
 
     sjrk.storyTelling.base.page.storyEdit.submitStory = function (storyEditorForm, storyModel, errorEvent) {
-        storyEditorForm.attr("action", "/stories/");
-        storyEditorForm.attr("method", "post");
-        storyEditorForm.attr("enctype", "multipart/form-data");
+        storyEditorForm.attr({
+            action: "/stories/",
+            method: "post",
+            enctype: "multipart/form-data"
+        });
 
         // This is the easiest way to be able to submit form
         // content in the background via ajax

--- a/src/ui/block-image.js
+++ b/src/ui/block-image.js
@@ -25,8 +25,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             singleTransform: {
                 type: "sjrk.storyTelling.transforms.arrayToString",
                 input: ["{that}.model.heading", "{that}.model.alternativeText", "{that}.model.description"],
-                separator: ". ",
-                stringOnly: true
+                delimiter: ". "
             }
         }
     });

--- a/src/ui/block-text.js
+++ b/src/ui/block-text.js
@@ -24,8 +24,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             singleTransform: {
                 type: "sjrk.storyTelling.transforms.arrayToString",
                 input: ["{that}.model.heading", "{that}.model.text"],
-                separator: ". ",
-                stringOnly: true
+                delimiter: ". "
             }
         }
     });

--- a/src/ui/block-timeBased.js
+++ b/src/ui/block-timeBased.js
@@ -26,8 +26,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             singleTransform: {
                 type: "sjrk.storyTelling.transforms.arrayToString",
                 input: ["{that}.model.heading", "{that}.model.alternativeText", "{that}.model.description", "{that}.model.transcript"],
-                separator: ". ",
-                stringOnly: true
+                delimiter: ". "
             }
         }
     });

--- a/src/ui/story.js
+++ b/src/ui/story.js
@@ -56,9 +56,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                     delimiter: ". ",
                     path: "contentString"
                 },
-                backward: {
-                    excludeSource: "*"
-                }
+                backward: "never"
             },
             tagsToKeywordString: {
                 source: "tags",

--- a/src/ui/story.js
+++ b/src/ui/story.js
@@ -53,9 +53,11 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 target: "contentString",
                 singleTransform: {
                     type: "sjrk.storyTelling.transforms.arrayToString",
-                    separator: ". ",
-                    stringOnly: true,
+                    delimiter: ". ",
                     path: "contentString"
+                },
+                backward: {
+                    excludeSource: "*"
                 }
             },
             tagsToKeywordString: {
@@ -63,7 +65,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 target: "keywordString",
                 singleTransform: {
                     type: "sjrk.storyTelling.transforms.arrayToString",
-                    separator: ", "
+                    delimiter: ", "
                 }
             }
         }

--- a/src/ui/story.js
+++ b/src/ui/story.js
@@ -47,24 +47,26 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             // ],
             // translationOf: null,
         },
-        modelRelay: [{
-            target: "contentString",
-            singleTransform: {
-                type: "sjrk.storyTelling.transforms.arrayToString",
-                input: "{that}.model.content",
-                separator: ". ",
-                stringOnly: true,
-                path: "contentString"
+        modelRelay: {
+            contentToContentString: {
+                target: "contentString",
+                singleTransform: {
+                    type: "sjrk.storyTelling.transforms.arrayToString",
+                    input: "{that}.model.content",
+                    separator: ". ",
+                    stringOnly: true,
+                    path: "contentString"
+                }
+            },
+            tagsToKeywordString: {
+                source: "tags",
+                target: "keywordString",
+                singleTransform: {
+                    type: "sjrk.storyTelling.transforms.arrayToString",
+                    separator: ", "
+                }
             }
-        },
-        {
-            source: "tags",
-            target: "keywordString",
-            singleTransform: {
-                type: "sjrk.storyTelling.transforms.arrayToString",
-                separator: ", "
-            }
-        }]
+        }
     });
 
 })(jQuery, fluid);

--- a/src/ui/story.js
+++ b/src/ui/story.js
@@ -49,10 +49,10 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         },
         modelRelay: {
             contentToContentString: {
+                source: "{that}.model.content",
                 target: "contentString",
                 singleTransform: {
                     type: "sjrk.storyTelling.transforms.arrayToString",
-                    input: "{that}.model.content",
                     separator: ". ",
                     stringOnly: true,
                     path: "contentString"

--- a/src/ui/transforms.js
+++ b/src/ui/transforms.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 OCAD University
+Copyright 2017-2019 OCAD University
 Licensed under the New BSD license. You may not use this file except in compliance with this licence.
 You may obtain a copy of the BSD License at
 https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENSE.txt
@@ -64,9 +64,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             path = extraInputs.path();
 
         fluid.each(input, function (term) {
-            if (path) {
-                term = fluid.get(term, path) || term;
-            }
+            term = fluid.get(term, path);
 
             if (!stringOnly || (term && typeof term === "string")) {
                 combinedString += term + (separator || "");

--- a/src/ui/transforms.js
+++ b/src/ui/transforms.js
@@ -16,8 +16,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     /* A transform to turn a delimited string into an array. If input is not a
      * string, then it will return an empty array.
      * It is partly invertible via "sjrk.storyTelling.transforms.arrayToString".
-     * - "delimiter": the delimiter of terms within the given strings
-     * - "trim": if true, trims excess whitespace from each term, otherwise no
+     * - "delimiter" (optional): the delimiter of terms within the given strings, defaults to ","
+     * - "trim" (optional): flag to trim excess whitespace from each term. defaults to true
      */
     fluid.defaults("sjrk.storyTelling.transforms.stringToArray", {
         gradeNames: ["fluid.standardTransformFunction"],
@@ -25,16 +25,13 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     });
 
     sjrk.storyTelling.transforms.stringToArray = function (input, transformSpec) {
-        var delimiter = transformSpec.delimiter || ",",
-            trim = transformSpec.trim;
-
-        trim = trim === undefined ? true : trim;
-
-        if (typeof input !== "string" || input === "") {
+        if (!input || typeof input !== "string") {
             return [];
         }
 
-        return fluid.transform(input.split(delimiter), function (tag) {
+        return fluid.transform(input.split(transformSpec.delimiter || ","), function (tag) {
+            var trim = fluid.isValue(transformSpec.trim) ? transformSpec.trim : true;
+
             if (trim) {
                 return tag.trim();
             } else {
@@ -51,8 +48,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     /* A transform to turn an array into a delimited string.
      * Values can also be accessed via a specific object path relative to each term.
      * It is partly invertible via "sjrk.storyTelling.transforms.stringToArray".
-     * - "delimiter" (optional): the delimiter to be inserted between each term
-     * - "stringOnly" (optional): flag to allow only non-empty strings
+     * - "delimiter" (optional): the delimiter to be inserted between each term. defaults to ", "
+     * - "stringOnly" (optional): flag to allow only non-empty strings. defaults to true
      * - "path" (optional): an EL path on each item in the terms collection
      */
     fluid.defaults("sjrk.storyTelling.transforms.arrayToString", {
@@ -62,10 +59,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
 
     sjrk.storyTelling.transforms.arrayToString = function (input, transformSpec) {
         var delimiter = transformSpec.delimiter || ", ",
-            stringOnly = transformSpec.stringOnly,
+            stringOnly = fluid.isValue(transformSpec.stringOnly) ? transformSpec.stringOnly : true,
             path = transformSpec.path || "";
-
-        stringOnly = stringOnly === undefined ? true : stringOnly;
 
         var terms = [];
 
@@ -77,7 +72,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             }
         });
 
-        return terms.join(delimiter || "");
+        return terms.join(delimiter);
     };
 
     sjrk.storyTelling.transforms.arrayToString.invert = function (transformSpec) {

--- a/src/ui/transforms.js
+++ b/src/ui/transforms.js
@@ -40,19 +40,18 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     };
 
     /* A transform to turn an array into a delimited string
-     * Values can be optionally be
-     * included only if they are string value and are truthy (i.e. not an empty
-     * string). Values can also be accessed via a specific path relative to each
-     * term.
-     * - "separator": the string delimiter to be inserted between each term
-     * - "stringOnly" (optional): flag to exclude all falsy or non-string values
+     * Values can also be accessed via a specific object path relative to each term.
+     * - "separator" (optional): the delimiter to be inserted between each term
+     * - "trailingSeparator" (optional): flag to include the separator at the end
+     * - "stringOnly" (optional): flag to allow only non-empty strings
      * - "path" (optional): an EL path on each item in the terms collection
      */
     fluid.defaults("sjrk.storyTelling.transforms.arrayToString", {
         "gradeNames": [ "fluid.standardTransformFunction", "fluid.multiInputTransformFunction" ],
         "inputVariables": {
             "separator": ", ",
-            "stringOnly": "",
+            "trailingSeparator": false,
+            "stringOnly": true,
             "path": ""
         }
     });
@@ -60,6 +59,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     sjrk.storyTelling.transforms.arrayToString = function (input, extraInputs) {
         var combinedString = "";
         var separator = extraInputs.separator(),
+            trailingSeparator = extraInputs.trailingSeparator(),
             stringOnly = extraInputs.stringOnly(),
             path = extraInputs.path();
 
@@ -71,7 +71,11 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             }
         });
 
-        return combinedString.substring(0, combinedString.lastIndexOf(separator));
+        if (!trailingSeparator) {
+            combinedString = combinedString.substring(0, combinedString.lastIndexOf(separator));
+        }
+
+        return combinedString;
     };
 
     /* A transform which, given a collection and an index, will the value of the

--- a/src/ui/transforms.js
+++ b/src/ui/transforms.js
@@ -25,19 +25,22 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     });
 
     sjrk.storyTelling.transforms.stringToArray = function (input, transformSpec) {
-        var sourceString = input,
-            delimiter = transformSpec.delimiter || ",",
+        var delimiter = transformSpec.delimiter || ",",
             trim = transformSpec.trim;
 
         trim = trim === undefined ? true : trim;
 
-        return typeof sourceString === "string" ? fluid.transform(sourceString.split(delimiter), function (tag) {
+        if (typeof input !== "string" || input === "") {
+            return [];
+        }
+
+        return fluid.transform(input.split(delimiter), function (tag) {
             if (trim) {
                 return tag.trim();
             } else {
                 return tag;
             }
-        }) : [];
+        });
     };
 
     sjrk.storyTelling.transforms.stringToArray.invert = function (transformSpec) {

--- a/src/ui/transforms.js
+++ b/src/ui/transforms.js
@@ -29,15 +29,16 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             return [];
         }
 
-        return fluid.transform(input.split(transformSpec.delimiter || ","), function (tag) {
-            var trim = fluid.isValue(transformSpec.trim) ? transformSpec.trim : true;
+        var resultArray = input.split(transformSpec.delimiter || ",");
 
-            if (trim) {
-                return tag.trim();
-            } else {
-                return tag;
-            }
-        });
+        var trimTerms = fluid.isValue(transformSpec.trim) ? transformSpec.trim : true;
+        if (trimTerms) {
+            return fluid.transform(resultArray, function (term) {
+                return term.trim();
+            });
+        }
+
+        return resultArray;
     };
 
     sjrk.storyTelling.transforms.stringToArray.invert = function (transformSpec) {

--- a/src/ui/transforms.js
+++ b/src/ui/transforms.js
@@ -44,9 +44,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
      * included only if they are string value and are truthy (i.e. not an empty
      * string). Values can also be accessed via a specific path relative to each
      * term.
-     * - separator: the string delimiter to be inserted between each term
-     * - stringOnly (optional): flag to exclude all falsy or non-string values
-     * - path (optional): an EL path on each item in the terms collection
+     * - "separator": the string delimiter to be inserted between each term
+     * - "stringOnly" (optional): flag to exclude all falsy or non-string values
+     * - "path" (optional): an EL path on each item in the terms collection
      */
     fluid.defaults("sjrk.storyTelling.transforms.arrayToString", {
         "gradeNames": [ "fluid.standardTransformFunction", "fluid.multiInputTransformFunction" ],
@@ -58,10 +58,10 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     });
 
     sjrk.storyTelling.transforms.arrayToString = function (input, extraInputs) {
-        var contentString = "";
-        var separator = extraInputs.separator();
-        var stringOnly = extraInputs.stringOnly();
-        var path = extraInputs.path();
+        var combinedString = "";
+        var separator = extraInputs.separator(),
+            stringOnly = extraInputs.stringOnly(),
+            path = extraInputs.path();
 
         fluid.each(input, function (term) {
             if (path) {
@@ -69,11 +69,11 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             }
 
             if (!stringOnly || (term && typeof term === "string")) {
-                contentString += term + (separator || "");
+                combinedString += term + (separator || "");
             }
         });
 
-        return contentString.substring(0, contentString.lastIndexOf(separator));
+        return combinedString.substring(0, combinedString.lastIndexOf(separator));
     };
 
     /* A transform which, given a collection and an index, will the value of the

--- a/tests/ui/js/base-page-storyEditTests.js
+++ b/tests/ui/js/base-page-storyEditTests.js
@@ -752,6 +752,14 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 }]
             },
             {
+                name: "Test isEmptyBlock function",
+                expect: 51,
+                sequence: [{
+                    funcName: "sjrk.storyTelling.base.page.storyEditTester.verifyIsEmptyBlock",
+                    args: ["{storyEdit}.options.blockContentValues"]
+                }]
+            },
+            {
                 name: "Test block filtering model relay: Text block",
                 expect: 13,
                 sequenceGrade: "sjrk.storyTelling.base.page.storyEditTester.textBlockModelRelaySequence"
@@ -869,6 +877,303 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
 
     sjrk.storyTelling.base.page.storyEditTester.getModelValueFromFieldName = function (component, fieldName) {
         return fluid.get(component, "story.model.content.0." + fieldName);
+    };
+
+    var isEmptyBlockTestCases = [
+        { block: {},            blockContentValues: "default",  expectedEmpty: true },
+        { block: [],            blockContentValues: "default",  expectedEmpty: true },
+        { block: "",            blockContentValues: "default",  expectedEmpty: true },
+        { block: "Not a block", blockContentValues: "default",  expectedEmpty: true },
+        { block: 0,             blockContentValues: "default",  expectedEmpty: true },
+        { block: 1,             blockContentValues: "default",  expectedEmpty: true },
+        { block: true,          blockContentValues: "default",  expectedEmpty: true },
+        { block: false,         blockContentValues: "default",  expectedEmpty: true },
+        { block: {},            blockContentValues: [],         expectedEmpty: true },
+        { block: [],            blockContentValues: [],         expectedEmpty: true },
+        { block: "",            blockContentValues: [],         expectedEmpty: true },
+        { block: "Not a block", blockContentValues: [],         expectedEmpty: true },
+        { block: 0,             blockContentValues: [],         expectedEmpty: true },
+        { block: 1,             blockContentValues: [],         expectedEmpty: true },
+        { block: true,          blockContentValues: [],         expectedEmpty: true },
+        { block: false,         blockContentValues: [],         expectedEmpty: true },
+        {
+            block: {
+                blockType: "text",
+                heading: "",
+                text: "An actual text value",
+                simplifiedText: ""
+            },                  blockContentValues: [],         expectedEmpty: true
+        },
+        { block: {},            blockContentValues: 0,          expectedEmpty: true },
+        { block: {},            blockContentValues: 1,          expectedEmpty: true },
+        { block: {},            blockContentValues: true,       expectedEmpty: true },
+        { block: {},            blockContentValues: false,      expectedEmpty: true },
+        { block: {},            blockContentValues: "",         expectedEmpty: true },
+        { block: {},            blockContentValues: "Useless",  expectedEmpty: true },
+        {
+            block: {
+                blockType: "text",
+                heading: "",
+                text: "An actual text value",
+                simplifiedText: ""
+            },                  blockContentValues: {},         expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "text",
+                heading: "",
+                text: "An actual text value",
+                simplifiedText: ""
+            },                  blockContentValues: 0,          expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "text",
+                heading: "",
+                text: "An actual text value",
+                simplifiedText: ""
+            },                  blockContentValues: 1,          expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "text"
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "text",
+                heading: "",
+                text: "",
+                simplifiedText: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "text",
+                heading: "",
+                text: "An actual text value",
+                simplifiedText: ""
+            },                  blockContentValues: "default",  expectedEmpty: false
+        },
+        {
+            block: {
+                blockType: "text",
+                heading: "An actual heading",
+                text: "",
+                simplifiedText: ""
+            },                  blockContentValues: "default",  expectedEmpty: false
+        },
+        {
+            block: {
+                blockType: "text",
+                heading: "",
+                text: "",
+                simplifiedText: "A value"
+            },                  blockContentValues: "default",  expectedEmpty: false
+        },
+        {
+            block: {
+                blockType: "image",
+                heading: "",
+                alternativeText: "",
+                description: "",
+                imageUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "image",
+                heading: "",
+                alternativeText: "",
+                description: "",
+                imageUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "image",
+                heading: "An actual heading",
+                alternativeText: "",
+                description: "",
+                imageUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "image",
+                heading: "",
+                alternativeText: "Some alternative text",
+                description: "",
+                imageUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "image",
+                heading: "",
+                alternativeText: "",
+                description: "A real description",
+                imageUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "image",
+                heading: "",
+                alternativeText: "",
+                description: "",
+                imageUrl: "Not really a URL"
+            },                  blockContentValues: "default",  expectedEmpty: false
+        },
+        {
+            block: {
+                blockType: "audio",
+                heading: "",
+                alternativeText: "",
+                description: "",
+                transcript: "",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "audio",
+                heading: "",
+                alternativeText: "",
+                description: "",
+                transcript: "",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "audio",
+                heading: "An actual heading",
+                alternativeText: "",
+                description: "",
+                transcript: "",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "audio",
+                heading: "",
+                alternativeText: "Some alternative text",
+                description: "",
+                transcript: "",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "audio",
+                heading: "",
+                alternativeText: "",
+                description: "A real description",
+                transcript: "",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "audio",
+                heading: "",
+                alternativeText: "",
+                description: "",
+                transcript: "A real transcript",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "audio",
+                heading: "",
+                alternativeText: "",
+                description: "",
+                transcript: "",
+                mediaUrl: "Not really a URL"
+            },                  blockContentValues: "default",  expectedEmpty: false
+        },
+        {
+            block: {
+                blockType: "video",
+                heading: "",
+                alternativeText: "",
+                description: "",
+                transcript: "",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "video",
+                heading: "",
+                alternativeText: "",
+                description: "",
+                transcript: "",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "video",
+                heading: "An actual heading",
+                alternativeText: "",
+                description: "",
+                transcript: "",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "video",
+                heading: "",
+                alternativeText: "Some alternative text",
+                description: "",
+                transcript: "",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "video",
+                heading: "",
+                alternativeText: "",
+                description: "A real description",
+                transcript: "",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "video",
+                heading: "",
+                alternativeText: "",
+                description: "",
+                transcript: "A real transcript",
+                mediaUrl: ""
+            },                  blockContentValues: "default",  expectedEmpty: true
+        },
+        {
+            block: {
+                blockType: "video",
+                heading: "",
+                alternativeText: "",
+                description: "",
+                transcript: "",
+                mediaUrl: "Not really a URL"
+            },                  blockContentValues: "default",  expectedEmpty: false
+        }
+    ];
+
+    sjrk.storyTelling.base.page.storyEditTester.verifyIsEmptyBlock = function (blockContentValues) {
+        fluid.each(isEmptyBlockTestCases, function (testCase, index) {
+            var blockContentValuesToUse = testCase.blockContentValues === "default" ? blockContentValues : testCase.blockContentValues;
+
+            var actuallyEmpty = sjrk.storyTelling.base.page.storyEdit.isEmptyBlock(testCase.block, blockContentValuesToUse[testCase.block.blockType]);
+            jqUnit.assertEquals("Block emptiness state for test case " + index + " is as expected", testCase.expectedEmpty, actuallyEmpty);
+        });
     };
 
     sjrk.storyTelling.base.page.storyEditTester.verifyPublishStates = function (expectedStates, progressArea, responseArea, shareButton) {

--- a/tests/ui/js/base-page-storyEditTests.js
+++ b/tests/ui/js/base-page-storyEditTests.js
@@ -80,7 +80,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         }
     });
 
-    var expectedVisibility = {
+    fluid.registerNamespace("sjrk.storyTelling.base.page.storyEditTester");
+    sjrk.storyTelling.base.page.storyEditTester.expectedVisibility = {
         prePublish: {
             progressArea: false,
             responseArea: false,
@@ -843,7 +844,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 expect: 10,
                 sequence: [{
                     funcName: "sjrk.storyTelling.base.page.storyEditTester.verifyPublishStates",
-                    args: [expectedVisibility.prePublish, "{storyEdit}.storyPreviewer.dom.progressArea", "{storyEdit}.storyPreviewer.dom.responseArea", "{storyEdit}.storyPreviewer.dom.storyShare"]
+                    args: [sjrk.storyTelling.base.page.storyEditTester.expectedVisibility.prePublish, "{storyEdit}.storyPreviewer.dom.progressArea", "{storyEdit}.storyPreviewer.dom.responseArea", "{storyEdit}.storyPreviewer.dom.storyShare"]
                 },
                 {
                     "jQueryTrigger": "click",
@@ -852,7 +853,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 {
                     "event": "{storyEdit}.events.onStoryShareRequested",
                     listener: "sjrk.storyTelling.base.page.storyEditTester.verifyPublishStates",
-                    args: [expectedVisibility.duringPublish, "{storyEdit}.storyPreviewer.dom.progressArea", "{storyEdit}.storyPreviewer.dom.responseArea", "{storyEdit}.storyPreviewer.dom.storyShare"]
+                    args: [sjrk.storyTelling.base.page.storyEditTester.expectedVisibility.duringPublish, "{storyEdit}.storyPreviewer.dom.progressArea", "{storyEdit}.storyPreviewer.dom.responseArea", "{storyEdit}.storyPreviewer.dom.storyShare"]
                 },
                 {
                     func: "{storyEdit}.events.onStoryShareComplete.fire",
@@ -861,7 +862,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 {
                     "event": "{storyEdit}.events.onStoryShareComplete",
                     listener: "sjrk.storyTelling.base.page.storyEditTester.verifyPublishStates",
-                    args: [expectedVisibility.postPublish, "{storyEdit}.storyPreviewer.dom.progressArea", "{storyEdit}.storyPreviewer.dom.responseArea", "{storyEdit}.storyPreviewer.dom.storyShare"]
+                    args: [sjrk.storyTelling.base.page.storyEditTester.expectedVisibility.postPublish, "{storyEdit}.storyPreviewer.dom.progressArea", "{storyEdit}.storyPreviewer.dom.responseArea", "{storyEdit}.storyPreviewer.dom.storyShare"]
                 },
                 {
                     funcName: "sjrk.storyTelling.base.page.storyEditTester.verifyResponseText",
@@ -879,153 +880,153 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         return fluid.get(component, "story.model.content.0." + fieldName);
     };
 
-    var isEmptyBlockTestCases = [
-        { block: {},            blockContentValues: "default",  expectedEmpty: true },
-        { block: [],            blockContentValues: "default",  expectedEmpty: true },
-        { block: "",            blockContentValues: "default",  expectedEmpty: true },
-        { block: "Not a block", blockContentValues: "default",  expectedEmpty: true },
-        { block: 0,             blockContentValues: "default",  expectedEmpty: true },
-        { block: 1,             blockContentValues: "default",  expectedEmpty: true },
-        { block: true,          blockContentValues: "default",  expectedEmpty: true },
-        { block: false,         blockContentValues: "default",  expectedEmpty: true },
-        { block: {},            blockContentValues: [],         expectedEmpty: true },
-        { block: [],            blockContentValues: [],         expectedEmpty: true },
-        { block: "",            blockContentValues: [],         expectedEmpty: true },
-        { block: "Not a block", blockContentValues: [],         expectedEmpty: true },
-        { block: 0,             blockContentValues: [],         expectedEmpty: true },
-        { block: 1,             blockContentValues: [],         expectedEmpty: true },
-        { block: true,          blockContentValues: [],         expectedEmpty: true },
-        { block: false,         blockContentValues: [],         expectedEmpty: true },
-        {
+    sjrk.storyTelling.base.page.storyEditTester.isEmptyBlockTestCases = {
+        "test_01": { expectedEmpty: true,   block: {} },
+        "test_02": { expectedEmpty: true,   block: [] },
+        "test_03": { expectedEmpty: true,   block: "" },
+        "test_04": { expectedEmpty: true,   block: "Not a block" },
+        "test_05": { expectedEmpty: true,   block: 0 },
+        "test_06": { expectedEmpty: true,   block: 1 },
+        "test_07": { expectedEmpty: true,   block: true },
+        "test_08": { expectedEmpty: true,   block: false },
+        "test_09": { expectedEmpty: true,   block: {} },
+        "test_10": { expectedEmpty: true,   blockContentValues: [],         block: [] },
+        "test_11": { expectedEmpty: true,   blockContentValues: [],         block: "" },
+        "test_12": { expectedEmpty: true,   blockContentValues: [],         block: "Not a block" },
+        "test_13": { expectedEmpty: true,   blockContentValues: [],         block: 0 },
+        "test_14": { expectedEmpty: true,   blockContentValues: [],         block: 1 },
+        "test_15": { expectedEmpty: true,   blockContentValues: [],         block: true },
+        "test_16": { expectedEmpty: true,   blockContentValues: [],         block: false },
+        "test_17": { expectedEmpty: true,   blockContentValues: [],
             block: {
                 blockType: "text",
                 heading: "",
                 text: "An actual text value",
                 simplifiedText: ""
-            },                  blockContentValues: [],         expectedEmpty: true
+            }
         },
-        { block: {},            blockContentValues: 0,          expectedEmpty: true },
-        { block: {},            blockContentValues: 1,          expectedEmpty: true },
-        { block: {},            blockContentValues: true,       expectedEmpty: true },
-        { block: {},            blockContentValues: false,      expectedEmpty: true },
-        { block: {},            blockContentValues: "",         expectedEmpty: true },
-        { block: {},            blockContentValues: "Useless",  expectedEmpty: true },
-        {
+        "test_18": { expectedEmpty: true,   blockContentValues: 0,          block: {} },
+        "test_19": { expectedEmpty: true,   blockContentValues: 1,          block: {} },
+        "test_20": { expectedEmpty: true,   blockContentValues: true,       block: {} },
+        "test_21": { expectedEmpty: true,   blockContentValues: false,      block: {} },
+        "test_22": { expectedEmpty: true,   blockContentValues: "",         block: {} },
+        "test_23": { expectedEmpty: true,   blockContentValues: "Useless",  block: {} },
+        "test_24": { expectedEmpty: true,   blockContentValues: {},
             block: {
                 blockType: "text",
                 heading: "",
                 text: "An actual text value",
                 simplifiedText: ""
-            },                  blockContentValues: {},         expectedEmpty: true
+            }
         },
-        {
+        "test_25": { expectedEmpty: true,   blockContentValues: 0,
             block: {
                 blockType: "text",
                 heading: "",
                 text: "An actual text value",
                 simplifiedText: ""
-            },                  blockContentValues: 0,          expectedEmpty: true
+            }
         },
-        {
+        "test_26": { expectedEmpty: true,   blockContentValues: 1,
             block: {
                 blockType: "text",
                 heading: "",
                 text: "An actual text value",
                 simplifiedText: ""
-            },                  blockContentValues: 1,          expectedEmpty: true
+            }
         },
-        {
+        "test_27": { expectedEmpty: true,
             block: {
                 blockType: "text"
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_28": { expectedEmpty: true,
             block: {
                 blockType: "text",
                 heading: "",
                 text: "",
                 simplifiedText: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_29": { expectedEmpty: false,
             block: {
                 blockType: "text",
                 heading: "",
                 text: "An actual text value",
                 simplifiedText: ""
-            },                  blockContentValues: "default",  expectedEmpty: false
+            }
         },
-        {
+        "test_30": { expectedEmpty: false,
             block: {
                 blockType: "text",
                 heading: "An actual heading",
                 text: "",
                 simplifiedText: ""
-            },                  blockContentValues: "default",  expectedEmpty: false
+            }
         },
-        {
+        "test_31": { expectedEmpty: false,
             block: {
                 blockType: "text",
                 heading: "",
                 text: "",
                 simplifiedText: "A value"
-            },                  blockContentValues: "default",  expectedEmpty: false
+            }
         },
-        {
+        "test_32": { expectedEmpty: true,
             block: {
                 blockType: "image",
                 heading: "",
                 alternativeText: "",
                 description: "",
                 imageUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_33": { expectedEmpty: true,
             block: {
                 blockType: "image",
                 heading: "",
                 alternativeText: "",
                 description: "",
                 imageUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_34": { expectedEmpty: true,
             block: {
                 blockType: "image",
                 heading: "An actual heading",
                 alternativeText: "",
                 description: "",
                 imageUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_35": { expectedEmpty: true,
             block: {
                 blockType: "image",
                 heading: "",
                 alternativeText: "Some alternative text",
                 description: "",
                 imageUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_36": { expectedEmpty: true,
             block: {
                 blockType: "image",
                 heading: "",
                 alternativeText: "",
                 description: "A real description",
                 imageUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_37": { expectedEmpty: false,
             block: {
                 blockType: "image",
                 heading: "",
                 alternativeText: "",
                 description: "",
                 imageUrl: "Not really a URL"
-            },                  blockContentValues: "default",  expectedEmpty: false
+            }
         },
-        {
+        "test_38": { expectedEmpty: true,
             block: {
                 blockType: "audio",
                 heading: "",
@@ -1033,9 +1034,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_39": { expectedEmpty: true,
             block: {
                 blockType: "audio",
                 heading: "",
@@ -1043,9 +1044,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_40": { expectedEmpty: true,
             block: {
                 blockType: "audio",
                 heading: "An actual heading",
@@ -1053,9 +1054,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_41": { expectedEmpty: true,
             block: {
                 blockType: "audio",
                 heading: "",
@@ -1063,9 +1064,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_42": { expectedEmpty: true,
             block: {
                 blockType: "audio",
                 heading: "",
@@ -1073,9 +1074,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "A real description",
                 transcript: "",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_43": { expectedEmpty: true,
             block: {
                 blockType: "audio",
                 heading: "",
@@ -1083,9 +1084,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "A real transcript",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_44": { expectedEmpty: false,
             block: {
                 blockType: "audio",
                 heading: "",
@@ -1093,9 +1094,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "",
                 mediaUrl: "Not really a URL"
-            },                  blockContentValues: "default",  expectedEmpty: false
+            }
         },
-        {
+        "test_45": { expectedEmpty: true,
             block: {
                 blockType: "video",
                 heading: "",
@@ -1103,9 +1104,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_46": { expectedEmpty: true,
             block: {
                 blockType: "video",
                 heading: "",
@@ -1113,9 +1114,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_47": { expectedEmpty: true,
             block: {
                 blockType: "video",
                 heading: "An actual heading",
@@ -1123,9 +1124,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_48": { expectedEmpty: true,
             block: {
                 blockType: "video",
                 heading: "",
@@ -1133,9 +1134,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_49": { expectedEmpty: true,
             block: {
                 blockType: "video",
                 heading: "",
@@ -1143,9 +1144,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "A real description",
                 transcript: "",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_50": { expectedEmpty: true,
             block: {
                 blockType: "video",
                 heading: "",
@@ -1153,9 +1154,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "A real transcript",
                 mediaUrl: ""
-            },                  blockContentValues: "default",  expectedEmpty: true
+            }
         },
-        {
+        "test_51": { expectedEmpty: false,
             block: {
                 blockType: "video",
                 heading: "",
@@ -1163,15 +1164,15 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 description: "",
                 transcript: "",
                 mediaUrl: "Not really a URL"
-            },                  blockContentValues: "default",  expectedEmpty: false
+            }
         }
-    ];
+    };
 
-    sjrk.storyTelling.base.page.storyEditTester.verifyIsEmptyBlock = function (blockContentValues) {
-        fluid.each(isEmptyBlockTestCases, function (testCase, index) {
-            var blockContentValuesToUse = testCase.blockContentValues === "default" ? blockContentValues : testCase.blockContentValues;
+    sjrk.storyTelling.base.page.storyEditTester.verifyIsEmptyBlock = function (defaultBlockContentValues) {
+        fluid.each(sjrk.storyTelling.base.page.storyEditTester.isEmptyBlockTestCases, function (testCase, index) {
+            var blockContentValuesToTest = fluid.isValue(testCase.blockContentValues) ? testCase.blockContentValues : defaultBlockContentValues;
 
-            var actuallyEmpty = sjrk.storyTelling.base.page.storyEdit.isEmptyBlock(testCase.block, blockContentValuesToUse[testCase.block.blockType]);
+            var actuallyEmpty = sjrk.storyTelling.base.page.storyEdit.isEmptyBlock(testCase.block, blockContentValuesToTest[testCase.block.blockType]);
             jqUnit.assertEquals("Block emptiness state for test case " + index + " is as expected", testCase.expectedEmpty, actuallyEmpty);
         });
     };

--- a/tests/ui/js/base-page-storyEditTests.js
+++ b/tests/ui/js/base-page-storyEditTests.js
@@ -139,7 +139,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             args: [
                 "Story model updated to expected value",
                 "{that}.options.value",
-                "@expand:sjrk.storyTelling.base.page.storyEditTester.getModelValueFromFieldName({storyEdit}.storyEditor,{that}.options.field)"
+                "@expand:sjrk.storyTelling.base.page.storyEditTester.getModelValueFromFieldName({storyEdit}.storyEditor, {that}.options.field)"
             ]
         }]
     });
@@ -159,6 +159,10 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             path: "content",
             listener: "jqUnit.assertDeepEq",
             args: ["Story model empty after removing value", [], "{storyEdit}.storyPreviewer.story.model.content"]
+        },
+        {
+            func: "jqUnit.assertEquals",
+            args: ["Story content string empty after removing value", "", "{storyEdit}.storyPreviewer.story.model.contentString"]
         }]
     });
 
@@ -176,6 +180,10 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         {
             funcName: "jqUnit.assertDeepEq",
             args: ["Story model remains empty after update", [], "{storyEdit}.storyPreviewer.story.model.content"]
+        },
+        {
+            func: "jqUnit.assertEquals",
+            args: ["Story content string remains empty after update", "", "{storyEdit}.storyPreviewer.story.model.contentString"]
         }]
     });
 
@@ -745,12 +753,12 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             },
             {
                 name: "Test block filtering model relay: Text block",
-                expect: 10,
+                expect: 13,
                 sequenceGrade: "sjrk.storyTelling.base.page.storyEditTester.textBlockModelRelaySequence"
             },
             {
                 name: "Test block filtering model relay: Image block",
-                expect: 12,
+                expect: 15,
                 sequenceGrade: "sjrk.storyTelling.base.page.storyEditTester.imageBlockModelRelaySequence",
                 sequence: [{
                     funcName: "jqUnit.assertEquals",
@@ -771,7 +779,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             },
             {
                 name: "Test block filtering model relay: Audio block",
-                expect: 14,
+                expect: 18,
                 sequenceGrade: "sjrk.storyTelling.base.page.storyEditTester.audioBlockModelRelaySequence",
                 sequence: [{
                     funcName: "jqUnit.assertEquals",
@@ -796,7 +804,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             },
             {
                 name: "Test block filtering model relay: Video block",
-                expect: 14,
+                expect: 18,
                 sequenceGrade: "sjrk.storyTelling.base.page.storyEditTester.videoBlockModelRelaySequence",
                 sequence: [{
                     funcName: "jqUnit.assertEquals",

--- a/tests/ui/js/storyTests.js
+++ b/tests/ui/js/storyTests.js
@@ -34,7 +34,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                     args: ["content", [{ contentString: "Cats" }]]
                 },
                 {
-                    funcName: "jqUnit.assertEquals",
+                    changeEvent: "{story}.applier.modelChanged",
+                    path: "content",
+                    listener: "jqUnit.assertEquals",
                     args: ["contentString is as expected", "Cats", "{story}.model.contentString"]
                 },
                 {
@@ -45,7 +47,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                     ]]
                 },
                 {
-                    funcName: "jqUnit.assertEquals",
+                    changeEvent: "{story}.applier.modelChanged",
+                    path: "content",
+                    listener: "jqUnit.assertEquals",
                     args: ["contentString is as expected", "Shyguy is a grey Mackerel Tabby with Bengal spots. Rootbeer is an grey-orange Mackerel Tabby with a few spots.", "{story}.model.contentString"]
                 }]
             }]

--- a/tests/ui/js/transformsTests.js
+++ b/tests/ui/js/transformsTests.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 OCAD University
+Copyright 2017-2019 OCAD University
 Licensed under the New BSD license. You may not use this file except in compliance with this licence.
 You may obtain a copy of the BSD License at
 https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENSE.txt
@@ -37,24 +37,102 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         jqUnit.assertDeepEq("Generated array values are as expected", expectedArray, tagArrayNoSpace);
     });
 
-    jqUnit.test("Test tagArrayToDisplayString function", function () {
-        jqUnit.expect(1);
+    var arrayToStringTransformTestCases = [
+        {
+            sourceArray: ["Shyguy", "Rootbeer"],
+            rules: {},
+            expectedResult: "Shyguy, Rootbeer"
+        },
+        {
+            sourceArray: ["Shyguy", "Rootbeer"],
+            rules: {
+                separator: ". "
+            },
+            expectedResult: "Shyguy. Rootbeer"
+        },
+        {
+            sourceArray: ["Shyguy", "Rootbeer"],
+            rules: {
+                separator: true
+            },
+            expectedResult: "ShyguytrueRootbeer"
+        },
+        {
+            sourceArray: ["Shyguy", "Rootbeer"],
+            rules: {
+                separator: 1
+            },
+            expectedResult: "Shyguy1Rootbeer"
+        },
+        {
+            sourceArray: ["Shyguy", "Rootbeer"],
+            rules: {
+                trailingSeparator: true
+            },
+            expectedResult: "Shyguy, Rootbeer, "
+        },
+        {
+            sourceArray: ["Shyguy", "Rootbeer", 0, {somethingElse: ""}, ["a string in an array"]],
+            rules: {},
+            expectedResult: "Shyguy, Rootbeer"
+        },
+        {
+            sourceArray: ["Shyguy", "Rootbeer", 0, {somethingElse: ""}, ["a string in an array"]],
+            rules: {
+                stringOnly: false
+            },
+            expectedResult: "Shyguy, Rootbeer, 0, [object Object], a string in an array"
+        },
+        {
+            sourceArray: ["Shyguy", "Rootbeer"],
+            rules: {
+                path: "innerPath"
+            },
+            expectedResult: ""
+        },
+        {
+            sourceArray: [
+                { innerPath: "Shyguy", ignoredValue: "Not a cat" },
+                { innerPath: "Rootbeer", ignoredValue: "Also not a cat" }
+            ],
+            rules: {
+                path: "innerPath"
+            },
+            expectedResult: "Shyguy, Rootbeer"
+        },
+        {
+            sourceArray: [
+                { innerPath: "Shyguy", ignoredValue: "Not a cat" },
+                { innerPath: "Rootbeer", ignoredValue: "Also not a cat" }
+            ],
+            rules: {
+                path: "notARealPath"
+            },
+            expectedResult: ""
+        },
+        {
+            sourceArray: ["Shyguy", "Rootbeer", "", false, {}, []],
+            rules: {},
+            expectedResult: "Shyguy, Rootbeer"
+        }
+    ];
 
-        var arrayToStringTransform = {
-            transform: {
+    jqUnit.test("Test arrayToString transform function", function () {
+        jqUnit.expect(arrayToStringTransformTestCases.length);
+
+        fluid.each(arrayToStringTransformTestCases, function (testCase, index) {
+            var transformRules = $.extend({}, testCase.rules, {
                 type: "sjrk.storyTelling.transforms.arrayToString",
-                inputPath: "sourceArray"
-            }
-        };
+                inputPath: "sourceArray",
+            })
 
-        var expectedString = "tag1, tag2";
+            var resultString = fluid.model.transformWithRules(
+                { sourceArray: testCase.sourceArray },
+                { resultString: { transform: transformRules }}
+            ).resultString;
 
-        var tagString = fluid.model.transformWithRules(
-            {sourceArray: ["tag1", "tag2"]},
-            {tagString: arrayToStringTransform}
-        ).tagString;
-
-        jqUnit.assertEquals("Generated array values are as expected", expectedString, tagString);
+            jqUnit.assertEquals("Generated array values for test case " + index + " are as expected", testCase.expectedResult, resultString);
+        });
     });
 
 })(jQuery, fluid);

--- a/tests/ui/js/transformsTests.js
+++ b/tests/ui/js/transformsTests.js
@@ -47,17 +47,17 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             expectedResult: ["Shyguy", "Rootbeer"]
         },
         {
+            input: ["Shyguy ,Rootbeer"],
+            rules: {},
+            expectedResult: []
+        },
+        {
             input: 0,
             rules: {},
             expectedResult: []
         },
         {
             input: {},
-            rules: {},
-            expectedResult: []
-        },
-        {
-            input: ["Shyguy ,Rootbeer"],
             rules: {},
             expectedResult: []
         },
@@ -70,6 +70,21 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             input: false,
             rules: {},
             expectedResult: []
+        },
+        {
+            input: "",
+            rules: {},
+            expectedResult: []
+        },
+        {
+            input: null,
+            rules: {},
+            expectedResult: []
+        },
+        {
+            input: undefined,
+            rules: {},
+            expectedResult: undefined
         }
     ];
 
@@ -99,6 +114,11 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     var arrayToStringTransformTestCases = [
         {
             input: ["Shyguy", "Rootbeer"],
+            rules: {},
+            expectedResult: "Shyguy, Rootbeer"
+        },
+        {
+            input: {cat1: "Shyguy", cat2: "Rootbeer"},
             rules: {},
             expectedResult: "Shyguy, Rootbeer"
         },
@@ -171,6 +191,31 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             input: [],
             rules: {},
             expectedResult: ""
+        },
+        {
+            input: 0,
+            rules: {},
+            expectedResult: ""
+        },
+        {
+            input: {},
+            rules: {},
+            expectedResult: ""
+        },
+        {
+            input: "",
+            rules: {},
+            expectedResult: ""
+        },
+        {
+            input: null,
+            rules: {},
+            expectedResult: ""
+        },
+        {
+            input: undefined,
+            rules: {},
+            expectedResult: undefined
         }
     ];
 

--- a/tests/ui/js/transformsTests.js
+++ b/tests/ui/js/transformsTests.js
@@ -11,87 +11,139 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
 
 (function ($, fluid) {
 
+    var stringToArrayTransformTestCases = [
+        {
+            input: "Shyguy,Rootbeer",
+            rules: {},
+            expectedResult: ["Shyguy", "Rootbeer"],
+            expectedInverseResult: "Shyguy, Rootbeer"
+        },
+        {
+            input: "Shyguy, Rootbeer",
+            rules: {},
+            expectedResult: ["Shyguy", "Rootbeer"],
+            expectedInverseResult: "Shyguy, Rootbeer"
+        },
+        {
+            input: "Shyguy   , Rootbeer",
+            rules: {
+                trim: false
+            },
+            expectedResult: ["Shyguy   ", " Rootbeer"],
+            expectedInverseResult: "Shyguy   , Rootbeer"
+        },
+        {
+            input: "Shyguy, Rootbeer",
+            rules: {
+                delimiter: "."
+            },
+            expectedResult: ["Shyguy, Rootbeer"]
+        },
+        {
+            input: "Shyguy. Rootbeer",
+            rules: {
+                delimiter: "."
+            },
+            expectedResult: ["Shyguy", "Rootbeer"]
+        },
+        {
+            input: 0,
+            rules: {},
+            expectedResult: []
+        },
+        {
+            input: {},
+            rules: {},
+            expectedResult: []
+        },
+        {
+            input: ["Shyguy ,Rootbeer"],
+            rules: {},
+            expectedResult: []
+        },
+        {
+            input: [],
+            rules: {},
+            expectedResult: []
+        },
+        {
+            input: false,
+            rules: {},
+            expectedResult: []
+        }
+    ];
+
     jqUnit.test("Test stringToArray transform function", function () {
-        jqUnit.expect(2);
+        jqUnit.expect(stringToArrayTransformTestCases.length);
 
-        var expectedArray = ["tag1","tag2"];
-
-        var stringToArrayTransform = {
-            transform: {
+        fluid.each(stringToArrayTransformTestCases, function (testCase, index) {
+            var transformRules = $.extend({}, testCase.rules, {
                 type: "sjrk.storyTelling.transforms.stringToArray",
                 inputPath: "inputString"
-            }
-        };
+            });
 
-        var tagArray = fluid.model.transformWithRules(
-            {inputString: "tag1,tag2"},
-            {output: stringToArrayTransform}
-        ).output;
+            var transform = {
+                transform: transformRules
+            };
 
-        var tagArrayNoSpace = fluid.model.transformWithRules(
-            {inputString: "tag1, tag2"},
-            {output: stringToArrayTransform}
-        ).output;
+            var output = fluid.model.transformWithRules(
+                { inputString: testCase.input },
+                { output: transform }
+            ).output;
 
-        jqUnit.assertDeepEq("Generated array values are as expected", expectedArray, tagArray);
-        jqUnit.assertDeepEq("Generated array values are as expected", expectedArray, tagArrayNoSpace);
+            jqUnit.assertDeepEq("Generated array values for test case " + index + " are as expected", testCase.expectedResult, output);
+
+        });
     });
 
     var arrayToStringTransformTestCases = [
         {
-            sourceArray: ["Shyguy", "Rootbeer"],
+            input: ["Shyguy", "Rootbeer"],
             rules: {},
             expectedResult: "Shyguy, Rootbeer"
         },
         {
-            sourceArray: ["Shyguy", "Rootbeer"],
+            input: ["Shyguy", "Rootbeer"],
             rules: {
-                separator: ". "
+                delimiter: ". "
             },
             expectedResult: "Shyguy. Rootbeer"
         },
         {
-            sourceArray: ["Shyguy", "Rootbeer"],
+            input: ["Shyguy", "Rootbeer"],
             rules: {
-                separator: true
+                delimiter: true
             },
             expectedResult: "ShyguytrueRootbeer"
         },
         {
-            sourceArray: ["Shyguy", "Rootbeer"],
+            input: ["Shyguy", "Rootbeer"],
             rules: {
-                separator: 1
+                delimiter: 1
             },
             expectedResult: "Shyguy1Rootbeer"
         },
         {
-            sourceArray: ["Shyguy", "Rootbeer"],
-            rules: {
-                trailingSeparator: true
-            },
-            expectedResult: "Shyguy, Rootbeer, "
-        },
-        {
-            sourceArray: ["Shyguy", "Rootbeer", 0, {somethingElse: ""}, ["a string in an array"]],
+            input: ["Shyguy", "Rootbeer", 0, {somethingElse: ""}, ["a string in an array"]],
             rules: {},
             expectedResult: "Shyguy, Rootbeer"
         },
         {
-            sourceArray: ["Shyguy", "Rootbeer", 0, {somethingElse: ""}, ["a string in an array"]],
+            input: ["Shyguy", "Rootbeer", 0, {somethingElse: ""}, ["a string in an array"]],
             rules: {
                 stringOnly: false
             },
             expectedResult: "Shyguy, Rootbeer, 0, [object Object], a string in an array"
         },
         {
-            sourceArray: ["Shyguy", "Rootbeer"],
+            input: ["Shyguy", "Rootbeer"],
             rules: {
                 path: "innerPath"
             },
             expectedResult: ""
         },
         {
-            sourceArray: [
+            input: [
                 { innerPath: "Shyguy", ignoredValue: "Not a cat" },
                 { innerPath: "Rootbeer", ignoredValue: "Also not a cat" }
             ],
@@ -101,7 +153,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             expectedResult: "Shyguy, Rootbeer"
         },
         {
-            sourceArray: [
+            input: [
                 { innerPath: "Shyguy", ignoredValue: "Not a cat" },
                 { innerPath: "Rootbeer", ignoredValue: "Also not a cat" }
             ],
@@ -111,9 +163,14 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             expectedResult: ""
         },
         {
-            sourceArray: ["Shyguy", "Rootbeer", "", false, {}, []],
+            input: ["Shyguy", "Rootbeer", "", false, {}, []],
             rules: {},
             expectedResult: "Shyguy, Rootbeer"
+        },
+        {
+            input: [],
+            rules: {},
+            expectedResult: ""
         }
     ];
 
@@ -123,15 +180,15 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         fluid.each(arrayToStringTransformTestCases, function (testCase, index) {
             var transformRules = $.extend({}, testCase.rules, {
                 type: "sjrk.storyTelling.transforms.arrayToString",
-                inputPath: "sourceArray",
-            })
+                inputPath: "sourceArray"
+            });
 
             var resultString = fluid.model.transformWithRules(
-                { sourceArray: testCase.sourceArray },
+                { sourceArray: testCase.input },
                 { resultString: { transform: transformRules }}
             ).resultString;
 
-            jqUnit.assertEquals("Generated array values for test case " + index + " are as expected", testCase.expectedResult, resultString);
+            jqUnit.assertEquals("Generated string value for test case " + index + " is as expected", testCase.expectedResult, resultString);
         });
     });
 

--- a/tests/ui/js/transformsTests.js
+++ b/tests/ui/js/transformsTests.js
@@ -11,158 +11,181 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
 
 (function ($, fluid) {
 
-    var stringToArrayTransformTestCases = [
-        {
+    var stringToArrayTransformTestCases = {
+        "test_01": {
             input: "Shyguy,Rootbeer",
             rules: {},
             expectedResult: ["Shyguy", "Rootbeer"],
             expectedInverseResult: "Shyguy, Rootbeer"
         },
-        {
+        "test_02": {
             input: "Shyguy, Rootbeer",
             rules: {},
             expectedResult: ["Shyguy", "Rootbeer"],
             expectedInverseResult: "Shyguy, Rootbeer"
         },
-        {
+        "test_03": {
             input: "Shyguy   , Rootbeer",
             rules: {
                 trim: false
             },
             expectedResult: ["Shyguy   ", " Rootbeer"],
-            expectedInverseResult: "Shyguy   , Rootbeer"
+            expectedInverseResult: "Shyguy   ,  Rootbeer"
         },
-        {
+        "test_04": {
             input: "Shyguy, Rootbeer",
             rules: {
                 delimiter: "."
             },
-            expectedResult: ["Shyguy, Rootbeer"]
+            expectedResult: ["Shyguy, Rootbeer"],
+            expectedInverseResult: "Shyguy, Rootbeer"
         },
-        {
+        "test_05": {
             input: "Shyguy. Rootbeer",
             rules: {
                 delimiter: "."
             },
-            expectedResult: ["Shyguy", "Rootbeer"]
+            expectedResult: ["Shyguy", "Rootbeer"],
+            expectedInverseResult: "Shyguy.Rootbeer"
         },
-        {
+        "test_06": {
             input: ["Shyguy ,Rootbeer"],
             rules: {},
-            expectedResult: []
+            expectedResult: [],
+            expectedInverseResult: ""
         },
-        {
+        "test_07": {
             input: 0,
             rules: {},
-            expectedResult: []
+            expectedResult: [],
+            expectedInverseResult: ""
         },
-        {
+        "test_08": {
             input: {},
             rules: {},
-            expectedResult: []
+            expectedResult: [],
+            expectedInverseResult: ""
         },
-        {
+        "test_09": {
             input: [],
             rules: {},
-            expectedResult: []
+            expectedResult: [],
+            expectedInverseResult: ""
         },
-        {
+        "test_10": {
             input: false,
             rules: {},
-            expectedResult: []
+            expectedResult: [],
+            expectedInverseResult: ""
         },
-        {
+        "test_11": {
             input: "",
             rules: {},
-            expectedResult: []
+            expectedResult: [],
+            expectedInverseResult: ""
         },
-        {
+        "test_12": {
             input: null,
             rules: {},
-            expectedResult: []
+            expectedResult: [],
+            expectedInverseResult: ""
         },
-        {
+        "test_13": {
             input: undefined,
             rules: {},
-            expectedResult: undefined
+            expectedResult: undefined,
+            expectedInverseResult: undefined
         }
-    ];
+    };
 
     jqUnit.test("Test stringToArray transform function", function () {
-        jqUnit.expect(stringToArrayTransformTestCases.length);
+        jqUnit.expect(26);
 
         fluid.each(stringToArrayTransformTestCases, function (testCase, index) {
-            var transformRules = $.extend({}, testCase.rules, {
+            var transformSpec = $.extend({}, testCase.rules, {
                 type: "sjrk.storyTelling.transforms.stringToArray",
                 inputPath: "inputString"
             });
 
-            var transform = {
-                transform: transformRules
+            var transformRules = {
+                transform: transformSpec
             };
 
             var output = fluid.model.transformWithRules(
                 { inputString: testCase.input },
-                { output: transform }
+                { output: transformRules }
             ).output;
-
             jqUnit.assertDeepEq("Generated array values for test case " + index + " are as expected", testCase.expectedResult, output);
 
+            var invertedRules = fluid.model.transform.invertConfiguration(transformRules);
+            var invertedOutput = fluid.model.transformWithRules(
+                output,
+                invertedRules
+            ).inputString;
+            jqUnit.assertEquals("Generated inverted string value for test case " + index + " is as expected", testCase.expectedInverseResult, invertedOutput);
         });
     });
 
-    var arrayToStringTransformTestCases = [
-        {
+    var arrayToStringTransformTestCases = {
+        "test_01": {
             input: ["Shyguy", "Rootbeer"],
             rules: {},
-            expectedResult: "Shyguy, Rootbeer"
+            expectedResult: "Shyguy, Rootbeer",
+            expectedInverseResult: ["Shyguy", "Rootbeer"]
         },
-        {
+        "test_02": {
             input: {cat1: "Shyguy", cat2: "Rootbeer"},
             rules: {},
-            expectedResult: "Shyguy, Rootbeer"
+            expectedResult: "Shyguy, Rootbeer",
+            expectedInverseResult: ["Shyguy", "Rootbeer"]
         },
-        {
+        "test_03": {
             input: ["Shyguy", "Rootbeer"],
             rules: {
                 delimiter: ". "
             },
-            expectedResult: "Shyguy. Rootbeer"
+            expectedResult: "Shyguy. Rootbeer",
+            expectedInverseResult: ["Shyguy", "Rootbeer"]
         },
-        {
+        "test_04": {
             input: ["Shyguy", "Rootbeer"],
             rules: {
                 delimiter: true
             },
-            expectedResult: "ShyguytrueRootbeer"
+            expectedResult: "ShyguytrueRootbeer",
+            expectedInverseResult: ["Shyguy", "Rootbeer"]
         },
-        {
+        "test_05": {
             input: ["Shyguy", "Rootbeer"],
             rules: {
                 delimiter: 1
             },
-            expectedResult: "Shyguy1Rootbeer"
+            expectedResult: "Shyguy1Rootbeer",
+            expectedInverseResult: ["Shyguy", "Rootbeer"]
         },
-        {
+        "test_06": {
             input: ["Shyguy", "Rootbeer", 0, {somethingElse: ""}, ["a string in an array"]],
             rules: {},
-            expectedResult: "Shyguy, Rootbeer"
+            expectedResult: "Shyguy, Rootbeer",
+            expectedInverseResult: ["Shyguy", "Rootbeer"]
         },
-        {
+        "test_07": {
             input: ["Shyguy", "Rootbeer", 0, {somethingElse: ""}, ["a string in an array"]],
             rules: {
                 stringOnly: false
             },
-            expectedResult: "Shyguy, Rootbeer, 0, [object Object], a string in an array"
+            expectedResult: "Shyguy, Rootbeer, 0, [object Object], a string in an array",
+            expectedInverseResult: ["Shyguy", "Rootbeer", "0", "[object Object]", "a string in an array"]
         },
-        {
+        "test_08": {
             input: ["Shyguy", "Rootbeer"],
             rules: {
                 path: "innerPath"
             },
-            expectedResult: ""
+            expectedResult: "",
+            expectedInverseResult: []
         },
-        {
+        "test_09": {
             input: [
                 { innerPath: "Shyguy", ignoredValue: "Not a cat" },
                 { innerPath: "Rootbeer", ignoredValue: "Also not a cat" }
@@ -170,9 +193,10 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             rules: {
                 path: "innerPath"
             },
-            expectedResult: "Shyguy, Rootbeer"
+            expectedResult: "Shyguy, Rootbeer",
+            expectedInverseResult: ["Shyguy", "Rootbeer"]
         },
-        {
+        "test_10": {
             input: [
                 { innerPath: "Shyguy", ignoredValue: "Not a cat" },
                 { innerPath: "Rootbeer", ignoredValue: "Also not a cat" }
@@ -180,60 +204,78 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             rules: {
                 path: "notARealPath"
             },
-            expectedResult: ""
+            expectedResult: "",
+            expectedInverseResult: []
         },
-        {
+        "test_11": {
             input: ["Shyguy", "Rootbeer", "", false, {}, []],
             rules: {},
-            expectedResult: "Shyguy, Rootbeer"
+            expectedResult: "Shyguy, Rootbeer",
+            expectedInverseResult: ["Shyguy", "Rootbeer"]
         },
-        {
+        "test_12": {
             input: [],
             rules: {},
-            expectedResult: ""
+            expectedResult: "",
+            expectedInverseResult: []
         },
-        {
+        "test_13": {
             input: 0,
             rules: {},
-            expectedResult: ""
+            expectedResult: "",
+            expectedInverseResult: []
         },
-        {
+        "test_14": {
             input: {},
             rules: {},
-            expectedResult: ""
+            expectedResult: "",
+            expectedInverseResult: []
         },
-        {
+        "test_15": {
             input: "",
             rules: {},
-            expectedResult: ""
+            expectedResult: "",
+            expectedInverseResult: []
         },
-        {
+        "test_16": {
             input: null,
             rules: {},
-            expectedResult: ""
+            expectedResult: "",
+            expectedInverseResult: []
         },
-        {
+        "test_17": {
             input: undefined,
             rules: {},
-            expectedResult: undefined
+            expectedResult: undefined,
+            expectedInverseResult: undefined
         }
-    ];
+    };
 
     jqUnit.test("Test arrayToString transform function", function () {
-        jqUnit.expect(arrayToStringTransformTestCases.length);
+        jqUnit.expect(34);
 
         fluid.each(arrayToStringTransformTestCases, function (testCase, index) {
-            var transformRules = $.extend({}, testCase.rules, {
+            var transformSpec = $.extend({}, testCase.rules, {
                 type: "sjrk.storyTelling.transforms.arrayToString",
                 inputPath: "sourceArray"
             });
 
+            var transformRules = {
+                transform: transformSpec
+            };
+
             var resultString = fluid.model.transformWithRules(
                 { sourceArray: testCase.input },
-                { resultString: { transform: transformRules }}
+                { resultString: transformRules }
             ).resultString;
-
             jqUnit.assertEquals("Generated string value for test case " + index + " is as expected", testCase.expectedResult, resultString);
+
+            var invertedRules = fluid.model.transform.invertConfiguration(transformRules);
+            var invertedOutput = fluid.model.transformWithRules(
+                resultString,
+                invertedRules
+            ).sourceArray;
+            jqUnit.assertDeepEq("Generated inverted array values for test case " + index + " are as expected", testCase.expectedInverseResult, invertedOutput);
         });
     });
 


### PR DESCRIPTION
This update fixes two bugs:
- the story being saved would save empty blocks
- the storySpeaker (text-to-speech) in the story preview would read out empty blocks