### PR TITLE
SJRK-306: UI rendering not working properly in IE11

### DIFF
--- a/src/ui/base-page.js
+++ b/src/ui/base-page.js
@@ -37,10 +37,12 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 target: "{that ui blockManager}.options.dynamicComponents.managedViewComponents.options.components.templateManager.options.templateConfig.resourcePrefix"
             },
             {
-                record: {
-                    "{page}.events.onContextChangeRequested": "{that}.stopMediaPlayer"
-                },
+                record: { "{page}.events.onContextChangeRequested": "{that}.stopMediaPlayer" },
                 target: "{that sjrk.storyTelling.blockUi.timeBased}.options.listeners"
+            },
+            {
+                record: { "{sjrk.storyTelling.base.page}.events.onRenderAllUiTemplates": "{templateManager}.events.onResourceLoadRequested.fire" },
+                target: "{that sjrk.storyTelling.ui}.options.listeners"
             },
             {
                 record: {
@@ -67,7 +69,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             onPreferenceLoadFailed: null,
             onContextChangeRequested: null, // this includes changes in visibility, language, etc.
             onUioReady: null,
-            onUioPanelsUpdated: null
+            onUioPanelsUpdated: null,
+            onRenderAllUiTemplates: null
         },
         listeners: {
             "onCreate.getStoredPreferences": {
@@ -107,8 +110,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
         },
         modelListeners: {
             uiLanguage: [{
-                funcName: "sjrk.storyTelling.base.page.renderAllUiTemplates",
-                args: ["{that}"],
+                funcName: "{that}.events.onRenderAllUiTemplates",
                 namespace: "renderAllUiTemplates"
             },
             {
@@ -177,17 +179,6 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             }
         }
     });
-
-    sjrk.storyTelling.base.page.renderAllUiTemplates = function (component) {
-        fluid.each(component, function (subcomponent) {
-            if (subcomponent &&
-                subcomponent.options &&
-                subcomponent.options.gradeNames &&
-                subcomponent.options.gradeNames.includes("sjrk.storyTelling.ui")) {
-                subcomponent.templateManager.events.onResourceLoadRequested.fire();
-            }
-        });
-    };
 
     sjrk.storyTelling.base.page.getStoredPreferences = function (pageComponent, cookieStore) {
         var promise = cookieStore.get();

--- a/tests/ui/js/base-pageTests.js
+++ b/tests/ui/js/base-pageTests.js
@@ -42,7 +42,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             name: "Test page grade",
             tests: [{
                 name: "Test events and timing",
-                expect: 24,
+                expect: 25,
                 sequence: [{
                     "event": "{pageTest testPage}.events.onAllUiComponentsReady",
                     "listener": "jqUnit.assert",
@@ -51,7 +51,16 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 // ensure the initial state is English
                 {
                     func: "{testPage}.applier.change",
+                    args: ["uiLanguage", ""]
+                },
+                {
+                    func: "{testPage}.applier.change",
                     args: ["uiLanguage", "en"]
+                },
+                {
+                    "event": "{testPage}.menu.events.onControlsBound",
+                    "listener": "jqUnit.assert",
+                    "args": "menu re-rendered after uiLanguage changed"
                 },
                 {
                     "jQueryTrigger": "click",
@@ -149,17 +158,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             },
             {
                 name: "Test functions and invokers",
-                expect: 22,
+                expect: 21,
                 sequence: [{
-                    "funcName": "sjrk.storyTelling.base.page.renderAllUiTemplates",
-                    "args": "{testPage}"
-                },
-                {
-                    "event": "{testPage}.menu.events.onControlsBound",
-                    "listener": "jqUnit.assert",
-                    "args": "menu re-rendered after call to renderAllUiTemplates"
-                },
-                {
                     "funcName": "sjrk.storyTelling.base.page.getStoredPreferences",
                     "args": ["{testPage}", "{testPage}.cookieStore"]
                 },


### PR DESCRIPTION
This update changes the way `ui` templates are re-rendered on uiLanguage change. Rather than relying on a clunky function that iterates over the `page` component's subcomponents to find every `ui` and call an event on it manually, we now use options distribution to inject a listener into each `ui` component. This is now all handled within Infusion fixtures and is less strongly coupled.