### PR TITLE
SJRK-312: added link to SJRK main website from SJRK theme masthead logo

### DIFF
--- a/themes/sojustrepairit/templates/sojustrepairit-masthead.handlebars
+++ b/themes/sojustrepairit/templates/sojustrepairit-masthead.handlebars
@@ -1,5 +1,5 @@
 <div class="sjrk-st-page-header">
-    <a href="/" class="sjrk-st-page-header-main-title" aria-label="{{localizedMessages.mastheadTitle}}"></a>
+    <a href="https://sojustrepairit.org" class="sjrk-st-page-header-main-title" aria-label="{{localizedMessages.mastheadTitle}}"></a>
 </div>
 <div class="sjrk-st-top-menu">
     <nav>


### PR DESCRIPTION
After this change is merged into the `stories-floe-dev` branch, it should be immediately merged from there into `stories-sojustrepairit-production`.