### PR TITLE
SJRK-326: solved page state bug caused by saving page model in cookie

### DIFF
--- a/src/ui/base-page-storyBrowse.js
+++ b/src/ui/base-page-storyBrowse.js
@@ -17,7 +17,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     fluid.defaults("sjrk.storyTelling.base.page.storyBrowse", {
         gradeNames: ["sjrk.storyTelling.base.page"],
         model: {
-            storyBrowseDisplayPreference: ""
+            persistedValues: {
+                storyBrowseDisplayPreference: ""
+            }
         },
         events: {
             onAllUiComponentsReady: {
@@ -35,7 +37,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                     listeners: {
                         "onViewChangeRequested.savePreference": {
                             func: "{storyBrowse}.applier.change",
-                            args: ["storyBrowseDisplayPreference", "{arguments}.0.data"],
+                            args: [["persistedValues", "storyBrowseDisplayPreference"], "{arguments}.0.data"],
                             priority: "first"
                         }
                     },
@@ -44,7 +46,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                             options: {
                                 model: {
                                     dynamicValues: {
-                                        storyBrowseDisplayPreference: "{storyBrowse}.model.storyBrowseDisplayPreference",
+                                        storyBrowseDisplayPreference: "{storyBrowse}.model.persistedValues.storyBrowseDisplayPreference",
                                         templateConfig: "{that}.options.templateConfig"
                                     }
                                 }

--- a/src/ui/base-page.js
+++ b/src/ui/base-page.js
@@ -17,7 +17,14 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     fluid.defaults("sjrk.storyTelling.base.page", {
         gradeNames: ["fluid.modelComponent"],
         model: {
-            // only values in this colleciton will be persisted by the cookieStore
+            // Only values in this colleciton will be persisted by the cookieStore.
+            //
+            // Currently, those values are the `uiLanguage` in this grade and
+            // `storyBrowseDisplayPreference` in `sjrk.storyTelling.base.page.storyBrowse`.
+            //
+            // The goal of separating them is to allow the use of other model values
+            // such as the view state values in `sjrk.storyTelling.base.page.storyEdit`
+            // without saving them.
             persistedValues: {
                 uiLanguage: "en" // initial locale set to match the initialModel below
             }

--- a/src/ui/base-page.js
+++ b/src/ui/base-page.js
@@ -17,12 +17,17 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
     fluid.defaults("sjrk.storyTelling.base.page", {
         gradeNames: ["fluid.modelComponent"],
         model: {
-            uiLanguage: "en" // initial locale set to match the initialModel below
+            // only values in this colleciton will be persisted by the cookieStore
+            persistedValues: {
+                uiLanguage: "en" // initial locale set to match the initialModel below
+            }
         },
         members: {
             initialModel: {
                 // the Initial Model of the page only specifies the locale
-                uiLanguage: "en" // default locale is set to English
+                persistedValues: {
+                    uiLanguage: "en" // default locale is set to English
+                }
             }
         },
         pageSetup: {
@@ -58,8 +63,8 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                     target: "{that}.model.locale",
                     singleTransform: {
                         type: "fluid.transforms.condition",
-                        condition: "{page}.model.uiLanguage",
-                        true: "{page}.model.uiLanguage",
+                        condition: "{page}.model.persistedValues.uiLanguage",
+                        true: "{page}.model.persistedValues.uiLanguage",
                         false: undefined
                     },
                     namespace: "uiLanguageToTemplateManager"
@@ -90,7 +95,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             },
             "{menu}.events.onInterfaceLanguageChangeRequested": [{
                 func: "{that}.applier.change",
-                args: ["uiLanguage", "{arguments}.0.data"],
+                args: [["persistedValues", "uiLanguage"], "{arguments}.0.data"],
                 namespace: "changeUiLanguage"
             },
             {
@@ -100,13 +105,13 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
             }]
         },
         modelListeners: {
-            uiLanguage: {
+            "persistedValues.uiLanguage": {
                 funcName: "{that}.events.onRenderAllUiTemplates",
                 namespace: "renderAllUiTemplates"
             },
             "": {
                 func: "{cookieStore}.set",
-                args: [null, "{page}.model"],
+                args: [null, "{page}.model.persistedValues"],
                 excludeSource: "init",
                 namespace: "setCookie"
             }
@@ -135,7 +140,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 container: ".flc-prefsEditor-separatedPanel",
                 options: {
                     model: {
-                        locale: "{page}.model.uiLanguage"
+                        locale: "{page}.model.persistedValues.uiLanguage"
                     },
                     listeners: {
                         "onUioReady.escalate": "{page}.events.onUioReady"
@@ -156,7 +161,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
 
         promise.then(function (response) {
             if (response !== undefined) {
-                pageComponent.applier.change("", response);
+                pageComponent.applier.change("persistedValues", response);
             }
             pageComponent.events.onPreferencesLoaded.fire();
         }, function (error) {

--- a/tests/ui/js/base-pageTests.js
+++ b/tests/ui/js/base-pageTests.js
@@ -52,11 +52,11 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 // ensure the initial state is English
                 {
                     func: "{testPage}.applier.change",
-                    args: ["uiLanguage", ""]
+                    args: [["persistedValues", "uiLanguage"], ""]
                 },
                 {
                     func: "{testPage}.applier.change",
-                    args: ["uiLanguage", "en"]
+                    args: [["persistedValues", "uiLanguage"], "en"]
                 },
                 {
                     "event": "{testPage}.menu.events.onControlsBound",
@@ -84,7 +84,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 },
                 {
                     funcName: "jqUnit.assertEquals",
-                    args: ["uiLanguage value is as expected", "es", "{testPage}.model.uiLanguage"]
+                    args: ["uiLanguage value is as expected", "es", "{testPage}.model.persistedValues.uiLanguage"]
                 },
                 {
                     "jQueryTrigger": "click",
@@ -107,7 +107,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 },
                 {
                     funcName: "jqUnit.assertEquals",
-                    args: ["uiLanguage value is as expected", "en", "{testPage}.model.uiLanguage"]
+                    args: ["uiLanguage value is as expected", "en", "{testPage}.model.persistedValues.uiLanguage"]
                 },
                 {
                     func: "{testPage}.menu.events.onInterfaceLanguageChangeRequested.fire",
@@ -124,9 +124,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 },
                 {
                     "changeEvent": "{testPage}.applier.modelChanged",
-                    "path": "uiLanguage",
+                    "path": "persistedValues.uiLanguage",
                     "funcName": "jqUnit.assertEquals",
-                    "args": ["uiLanguage is as expected" ,"es", "{testPage}.model.uiLanguage"]
+                    "args": ["uiLanguage is as expected" ,"es", "{testPage}.model.persistedValues.uiLanguage"]
                 },
                 {
                     func: "{testPage}.menu.events.onInterfaceLanguageChangeRequested.fire",
@@ -134,9 +134,9 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 },
                 {
                     "changeEvent": "{testPage}.applier.modelChanged",
-                    "path": "uiLanguage",
+                    "path": "persistedValues.uiLanguage",
                     "funcName": "jqUnit.assertEquals",
-                    "args": ["uiLanguage is as expected" ,"en", "{testPage}.model.uiLanguage"]
+                    "args": ["uiLanguage is as expected" ,"en", "{testPage}.model.persistedValues.uiLanguage"]
                 },
                 {
                     func: "{testPage}.menu.events.onInterfaceLanguageChangeRequested.fire",
@@ -144,19 +144,19 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 },
                 {
                     "changeEvent": "{testPage}.applier.modelChanged",
-                    "path": "uiLanguage",
+                    "path": "persistedValues.uiLanguage",
                     "funcName": "jqUnit.assertEquals",
-                    "args": ["uiLanguage is as expected" ,"cattish", "{testPage}.model.uiLanguage"]
+                    "args": ["uiLanguage is as expected" ,"cattish", "{testPage}.model.persistedValues.uiLanguage"]
                 },
                 {
                     func: "{testPage}.applier.change",
-                    args: ["uiLanguage", "en"]
+                    args: [["persistedValues", "uiLanguage"], "en"]
                 },
                 {
                     "changeEvent": "{testPage}.applier.modelChanged",
-                    "path": "uiLanguage",
+                    "path": "persistedValues.uiLanguage",
                     "funcName": "jqUnit.assertEquals",
-                    "args": ["uiLanguage is as expected" ,"en", "{testPage}.model.uiLanguage"]
+                    "args": ["uiLanguage is as expected" ,"en", "{testPage}.model.persistedValues.uiLanguage"]
                 }]
             },
             {
@@ -177,7 +177,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 expect: 5,
                 sequence: [{
                     "func": "{testPage}.applier.change",
-                    "args": ["uiLanguage", "meowish"]
+                    "args": [["persistedValues", "uiLanguage"], "meowish"]
                 },
                 {
                     "event": "{testPage}.cookieStore.events.onWriteResponse",
@@ -186,7 +186,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 },
                 {
                     "func": "{testPage}.applier.change",
-                    "args": ["fuzzyCat", "yes please"]
+                    "args": [["persistedValues", "fuzzyCat"], "yes please"]
                 },
                 {
                     "event": "{testPage}.cookieStore.events.onWriteResponse",
@@ -200,7 +200,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/master/LICENS
                 {
                     "event": "{testPage}.events.onPreferencesLoaded",
                     "listener": "jqUnit.assertEquals",
-                    "args": ["Language is still as expected after cookie load", "meowish", "{testPage}.model.uiLanguage"]
+                    "args": ["Language is still as expected after cookie load", "meowish", "{testPage}.model.persistedValues.uiLanguage"]
                 },
                 // reset the cookie to its initial state for subsequent test runs
                 {


### PR DESCRIPTION
The bug was due to the entire `page` component's model being saved to the `cookieStore`, including the view state values.

The solution is to keep the stored values in a specific collection called `persistedValues`. The `uiLanguage` and `storyBrowseDisplayPreference` keys have been added to that collection, as nothing else at this point needs to be persisted, and tests have been adjusted accordingly.