### PR TITLE
SJRK-317 & SJRK-309

### DIFF
--- a/src/server/dataSource.js
+++ b/src/server/dataSource.js
@@ -51,7 +51,7 @@ fluid.defaults("sjrk.storyTelling.server.dataSource.couch.view", {
     path: "/%db/_design/%designDoc/_view/%viewId?limit=%limit&reduce=%reduce&skip=%skip",
     termMap: {
         viewId: "%directViewId",
-        limit: "100",
+        limit: "500",
         reduce: "false",
         db: "stories",
         designDoc: "stories",

--- a/src/server/middleware/saveStoryWithBinaries.js
+++ b/src/server/middleware/saveStoryWithBinaries.js
@@ -22,7 +22,7 @@ fluid.defaults("sjrk.storyTelling.server.middleware.saveStoryWithBinaries", {
     formFieldOptions: {
         method: "fields",
         fields: [
-            {name: "file", maxCount: 10},
+            {name: "file", maxCount: 50},
             {name: "model", maxCount: 1}
         ]
     },


### PR DESCRIPTION
This pull request tackles two issues simultaneously for the sake of expedience:
[SJRK-309: Consider increasing maximum number of files in story](https://issues.fluidproject.org/browse/SJRK-309)
[SJRK-317: 100-story limit on Browse page](https://issues.fluidproject.org/browse/SJRK-317)

The story limit on the Browse page has been bumped from 100 to 500, while the maximum number of files in a story is 50 up from 10.