### PR TITLE
SJRK-361: Pin Node.js version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:10.21.0-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
With GitHub Actions, I cannot force a build without creating a commit. In Jenkins, we'd just push the build button to re-run a job.

That means that whenever there's an update to Node.js, we don't have a way to update the actual containers that are running with the new image because we're using `FROM node:10-alpine`.

I'm proposing we pin the Node.js version here so every new version requires a PR/commit that will in turn trigger the CI/CD job that will deploy new containers.

I think this will have to be our strategy for Docker images going forward.