### PR TITLE
SJRK-362 Only run deploy on origin repository

### DIFF
--- a/.github/workflows/docker-image-push.yml
+++ b/.github/workflows/docker-image-push.yml
@@ -15,8 +15,9 @@ env:
 
 jobs:
   push:
-    runs-on: ubuntu-latest
     if: github.repository == 'fluid-project/sjrk-story-telling'
+
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/stack_master.yml
+++ b/.github/workflows/stack_master.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   deploy:
+    if: github.repository == 'fluidproject/sjrk-story-telling'
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/stack_stories-aihec-production.yml
+++ b/.github/workflows/stack_stories-aihec-production.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   deploy:
+    if: github.repository == 'fluidproject/sjrk-story-telling'
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/stack_stories-cities-production.yml
+++ b/.github/workflows/stack_stories-cities-production.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   deploy:
+    if: github.repository == 'fluidproject/sjrk-story-telling'
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/stack_stories-floe-production.yml
+++ b/.github/workflows/stack_stories-floe-production.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   deploy:
+    if: github.repository == 'fluidproject/sjrk-story-telling'
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/stack_stories-karisma-production.yml
+++ b/.github/workflows/stack_stories-karisma-production.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   deploy:
+    if: github.repository == 'fluidproject/sjrk-story-telling'
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/stack_stories-sojustrepairit-production.yml
+++ b/.github/workflows/stack_stories-sojustrepairit-production.yml
@@ -11,6 +11,8 @@ env:
 
 jobs:
   deploy:
+    if: github.repository == 'fluidproject/sjrk-story-telling'
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
If deploy job runs on forked repository, it'll fail (as expected and desired). This limits where/when the deploy job will run to only the origin repository for SJRK.