### PR TITLE
SJRK-375: Add daily cleanup workflow for staging-stories.floeproject.org

### DIFF
--- a/.github/workflows/stack_master.yml
+++ b/.github/workflows/stack_master.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      # This step also exists in stack_master_cleanup.yml
       - name: Deploy stack
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/stack_master_cleanup.yml
+++ b/.github/workflows/stack_master_cleanup.yml
@@ -34,6 +34,7 @@ jobs:
             rm -rf ../uploads/*                                       && \
             rm -rf ../deleted_uploads/*
 
+      # This step duplicates code from stack_master.yml
       - name: Redeploy stack
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/stack_master_cleanup.yml
+++ b/.github/workflows/stack_master_cleanup.yml
@@ -1,0 +1,59 @@
+name: staging-stories.floeproject.org daily cleanup
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  PROJECT_ID: 006fb6eb
+  PROJECT_SMOKETEST_URL: https://staging-stories.floeproject.org/stories
+
+jobs:
+  deploy:
+    if: github.repository == 'fluid-project/sjrk-story-telling'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Stop and clean resources
+        uses: appleboy/ssh-action@master
+        with:
+          host:     ${{ secrets.SSH_HOSTNAME }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key:      ${{ secrets.SSH_PRIVATE_KEY }}
+          port:     ${{ secrets.SSH_PORT }}
+          envs:     PROJECT_ID
+          script: |
+            cd /srv/$PROJECT_ID/src                                   && \
+            source ../deploy.env                                      && \
+            /usr/local/bin/docker-compose -p $PROJECT_ID                 \
+                                          -f docker-compose.yml          \
+                                          -f docker-compose.cloud.yml    \
+                                          down                        && \
+            rm -rf ../couchdb/*                                       && \
+            rm -rf ../uploads/*                                       && \
+            rm -rf ../deleted_uploads/*
+
+      - name: Redeploy stack
+        uses: appleboy/ssh-action@master
+        with:
+          host:     ${{ secrets.SSH_HOSTNAME }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key:      ${{ secrets.SSH_PRIVATE_KEY }}
+          port:     ${{ secrets.SSH_PORT }}
+          envs:     PROJECT_ID
+          script: |
+            cd /srv/$PROJECT_ID/src                                       && \
+            git checkout master                                           && \
+            git pull                                                      && \
+            source ../deploy.env                                          && \
+            /usr/local/bin/docker-compose -p $PROJECT_ID                     \
+                                          -f docker-compose.yml              \
+                                          -f docker-compose.cloud.yml        \
+                                          up --force-recreate --build -d
+
+      - name: Wait
+        run: sleep 15
+
+      - name: Smoke test
+        run: curl --location --no-buffer --retry 120 --retry-delay 1 $PROJECT_SMOKETEST_URL


### PR DESCRIPTION
https://issues.fluidproject.org/browse/SJRK-375

I really hate to have the "Redeploy stack" step here because it's not DRY (the code is already defined in the stack_master.yml workflow). But to trigger another workflow from this one would require 3x more code, the creation of a read-write GitHub token, etc. It's just not worth it for a single step.