### PR TITLE
SJRK-425: allow stories without the published flag to be accessed/listed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sjrk-story-telling",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "The Storytelling Project with Kettle-based server and CouchDB interface",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sjrk-story-telling",
-    "version": "0.4.1",
+    "version": "0.4.0",
     "description": "The Storytelling Project with Kettle-based server and CouchDB interface",
     "main": "index.js",
     "scripts": {

--- a/src/server/db/story-dbConfiguration.js
+++ b/src/server/db/story-dbConfiguration.js
@@ -141,7 +141,8 @@ sjrk.storyTelling.server.storiesDb.storyTagsFunction = function (doc) {
  * @param {Object} doc - a document to evaluate in the view
  */
 sjrk.storyTelling.server.storiesDb.storiesByIdFunction = function (doc) {
-    if (doc.value.published) {
+    // only returns published stories or stories that predate the "published" flag
+    if (typeof doc.value.published === "undefined" || doc.value.published) {
         var browseDoc = {
             "title": doc.value.title,
             "author": doc.value.author,

--- a/src/server/db/story-dbConfiguration.js
+++ b/src/server/db/story-dbConfiguration.js
@@ -141,6 +141,10 @@ sjrk.storyTelling.server.storiesDb.storyTagsFunction = function (doc) {
  * @param {Object} doc - a document to evaluate in the view
  */
 sjrk.storyTelling.server.storiesDb.storiesByIdFunction = function (doc) {
+    // TODO: this restriction should be reverted to allow only published stories
+    // once the flag is present in all previously-published stories. Please see
+    // SJRK-425 for more info: https://issues.fluidproject.org/browse/SJRK-425
+
     // only returns published stories or stories that predate the "published" flag
     if (typeof doc.value.published === "undefined" || doc.value.published) {
         var browseDoc = {

--- a/src/server/requestHandlers.js
+++ b/src/server/requestHandlers.js
@@ -117,7 +117,8 @@ sjrk.storyTelling.server.handleGetStory = function (request, dataSource) {
     var noAccessErrorMessage = "An error occurred while retrieving the requested story";
 
     promise.then(function (response) {
-        if (response.published) {
+        // only returns published stories or stories that predate the "published" flag
+        if (typeof response.published === "undefined" || response.published) {
             request.events.onSuccess.fire(JSON.stringify(response));
         } else {
             fluid.log(fluid.logLevel.WARN, "Unauthorized: cannot access an unpublished story: " + id);

--- a/src/server/requestHandlers.js
+++ b/src/server/requestHandlers.js
@@ -117,6 +117,10 @@ sjrk.storyTelling.server.handleGetStory = function (request, dataSource) {
     var noAccessErrorMessage = "An error occurred while retrieving the requested story";
 
     promise.then(function (response) {
+        // TODO: this restriction should be reverted to allow only published stories
+        // once the flag is present in all previously-published stories. Please see
+        // SJRK-425 for more info: https://issues.fluidproject.org/browse/SJRK-425
+
         // only returns published stories or stories that predate the "published" flag
         if (typeof response.published === "undefined" || response.published) {
             request.events.onSuccess.fire(JSON.stringify(response));


### PR DESCRIPTION
At some point, we should add the `published` flag to the records that don't have it and then revert this work.