### PR TITLE
SJRK-425: restore published story restriction, adjust tests and add migration scripts

### DIFF
--- a/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/aihec_stories_0.3.0_to_0.4.0_documents.js
+++ b/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/aihec_stories_0.3.0_to_0.4.0_documents.js
@@ -1,0 +1,305 @@
+/*
+For copyright information, see the AUTHORS.md file in the docs directory of this distribution and at
+https://github.com/fluid-project/sjrk-story-telling/blob/main/docs/AUTHORS.md
+
+Licensed under the New BSD license. You may not use this file except in compliance with this licence.
+You may obtain a copy of the BSD License at
+https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.txt
+*/
+
+// These eslint directives prevent the linter from complaining about the use of
+// globals or arguments that will be prevent in CouchDB design doc functions
+// such as views or validate_doc_update
+
+"use strict";
+
+require("infusion");
+require("kettle");
+
+require("fluid-couch-config");
+
+// sets up the Storytelling Tool database migration using fluid-couch-config
+fluid.defaults("sjrk.storyTelling.server.storiesDb", {
+    gradeNames: ["fluid.couchConfig.pipeline.retrying"],
+    couchOptions: {
+        dbName: "stories"
+    },
+    listeners: {
+        "onSuccess.logSuccess": "fluid.log(SUCCESS)",
+        "onError.logError": "fluid.log({arguments}.0.message)"
+    },
+    dbDocuments: {
+        "8ddcf990-8e18-11ea-820b-c9772cf8ea15":
+        {
+            "type": "story",
+            "value":
+            {
+                "id": "8ddcf990-8e18-11ea-820b-c9772cf8ea15",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title":"Taking Care of Others",
+                "content":
+                [
+                    {
+                        "id":null,
+                        "language":null,
+                        "heading":null,
+                        "blockType":"text",
+                        "text":"When the people were still getting around in wagons, there was a family who needed food before a snowstorm. The husband told his wife he would make a trip to the store to get food. The husband told his wife and children to stay home and she agreed. The husband left. "
+                    },
+                    {
+                        "id":null,
+                        "language":null,
+                        "heading":null,
+                        "blockType":"image",
+                        "mediaUrl":"./uploads/8dd29950-8e18-11ea-820b-c9772cf8ea15.jpg",
+                        "description":null,
+                        "fileDetails":
+                        {
+                            "lastModified":1588604206480,
+                            "lastModifiedDate":"2020-05-04T14:56:46.480Z",
+                            "name":"oregon-trail-4217528_1920.jpg",
+                            "size":3294364,
+                            "type":"image/png"
+                        },
+                        "alternativeText":"Covered wagons"
+                    },
+                    {
+                        "id":null,
+                        "language":null,
+                        "heading":null,
+                        "blockType":"text",
+                        "text":"It was getting later and later the wife was getting worried. The husband got caught in the snowstorm on his way home. The snow was blowing hard and it was getting cold; he was losing feelings in his legs. He was trying to keep warm by the wagon when he heard someone singing. "
+                    },
+                    {
+                        "id":null,
+                        "language":null,
+                        "heading":null,
+                        "blockType":"image",
+                        "mediaUrl":"./uploads/8dd44700-8e18-11ea-820b-c9772cf8ea15.jpg",
+                        "alternativeText":null,
+                        "description":null,
+                        "fileDetails":
+                        {
+                            "lastModified":1588604260320,
+                            "lastModifiedDate":"2020-05-04T14:57:40.320Z",
+                            "name":"pine-tree-4666369_1920.jpg",
+                            "size":3490136,
+                            "type":"image/png"
+                        }
+                    },
+                    {
+                        "id":null,
+                        "language":null,
+                        "heading":null,
+                        "blockType":"text",
+                        "text":"He saw a light on the top of the hill, so he went that way. When he got on top of the hill, he saw rabbits singing and dancing. He watched them all night and before he knew it the weather cleared up and he was able to get home. "
+                    },
+                    {
+                        "id":null,
+                        "language":null,
+                        "heading":null,
+                        "blockType":"image",
+                        "mediaUrl":"./uploads/8dd75440-8e18-11ea-820b-c9772cf8ea15.jpg",
+                        "description":null,
+                        "fileDetails":
+                        {
+                            "lastModified":1588604294661,
+                            "lastModifiedDate":"2020-05-04T14:58:14.661Z",
+                            "name":"rabbit-2910054_1920.jpg",
+                            "size":3790498,
+                            "type":"image/png"
+                        },
+                        "alternativeText":"rabbit in snow"
+                    },
+                    {
+                        "id":null,
+                        "language":null,
+                        "heading":null,
+                        "blockType":"text",
+                        "text":"Before he left, he was told by the rabbits that they took pity on him and saved his life. When he returned home, he told what he saw and how the rabbits saved his life."
+                    },
+                    {
+                        "id":null,
+                        "language":null,
+                        "heading":null,
+                        "blockType":"image",
+                        "mediaUrl":"./uploads/8dd901f0-8e18-11ea-820b-c9772cf8ea15.jpg",
+                        "alternativeText":null,
+                        "description":null,
+                        "fileDetails":
+                        {
+                            "lastModified":1588604338333,
+                            "lastModifiedDate":"2020-05-04T14:58:58.333Z",
+                            "name":"snow-3704236_1920.jpg",
+                            "size":4023021,"type":"image/png"
+                        }
+                    }
+                ],
+                "author":"Melody Hill told to her by her father, Ephraim Hill",
+                "tags":[]
+            }
+        },
+        "96f85d00-8a74-11ea-820b-c9772cf8ea15":
+        {
+            "type": "story",
+            "value":
+            {
+                "id": "96f85d00-8a74-11ea-820b-c9772cf8ea15",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content":
+                [
+                    {
+                        "id":null,
+                        "language":null,
+                        "blockType":"text",
+                        "heading":"Dagot'éé! (Hello! How's it going?)",
+                        "text":"Here at San Carlos Apache College, we recognize and celebrate the unique opportunities that we offer to our students here at this Tribal College. Among these are the Apache language, history, and art classes that we are quite certain are not offered in any other institute of higher learning in the world! One of the initiatives that the College kickstarted in Spring 2019 was the encouragement and support of ALL staff to take one of these unique classes, as a way to more deeply connect with our local community and culture. It was an honor for me to be among the first to take Apache Language 101 as an employee!"
+                    },
+                    {
+                        "id":null,
+                        "language":null,
+                        "blockType":"image",
+                        "mediaUrl":"./uploads/95669970-8a74-11ea-820b-c9772cf8ea15.jpg",
+                        "fileDetails":
+                        {
+                            "lastModified":1547658304550,
+                            "lastModifiedDate":"2019-01-16T17:05:04.550Z",
+                            "name":"20190116_0855_9198.jpg",
+                            "size":2145749,"type":"image/png"
+                        },
+                        "heading":"Getting Ready for Class",
+                        "description":"Armed with a notebook, voice recorder, video camera, and one of the few Apache-English dictionaries in existence, I took my task as a language learner seriously. I stayed up many long nights reviewing my recordings and immersing myself in the language.",
+                        "alternativeText":"Photo of a tabletop with a notebook full of notes in the Apache language, Apache language flash cards, a voice recorder, a USB flash drive, and a pen."
+                    },
+                    {
+                        "id":null,
+                        "language":null,
+                        "blockType":"image",
+                        "mediaUrl":"./uploads/95686e30-8a74-11ea-820b-c9772cf8ea15.png",
+                        "fileDetails":
+                        {
+                            "lastModified":1588135604350,
+                            "lastModifiedDate":"2020-04-29T04:46:44.350Z",
+                            "name":"Screen Shot 2020-04-28 at 9.46.38 PM.png",
+                            "size":452443,
+                            "type":"image/png"
+                        },
+                        "heading":"Learning about Family",
+                        "description":"It is impossible to learn the Apache language without also learning about Apache culture. For example, I got to study the many kinship terms that are essential in Apache culture. I also learned about traditional Apache foods, animals, and songs.","alternativeText":"Family tree diagram with Apache kinship terms."
+                    },
+                    {
+                        "id":null,
+                        "language":null,
+                        "mediaUrl":"./uploads/9569cdc0-8a74-11ea-820b-c9772cf8ea15.mov",
+                        "alternativeText":null,
+                        "blockType":"video",
+                        "fileDetails":
+                        {
+                            "lastModified":1554949908168,
+                            "lastModifiedDate":"2019-04-11T02:31:48.168Z",
+                            "name":"20190408 Lily Apache Animals Book-YouTube Optimized.mov",
+                            "size":460548106,
+                            "type":"video/quicktime"
+                        },
+                        "heading":"Teaching Apache to My Daughter",
+                        "description":"By the end of the semester, I wrote and illustrated a children's book using what I had learned in my Apache language class. I dedicated this labor of love to her and I was thrilled to see that she enjoyed it. In this video, I'm reading a draft of it to my 2-year-old daughter for the first time, and you can actually see us switch between English, Cantonese, Apache, and American Sign Language as we discuss the story! "
+                    },
+                    {
+                        "id":null,
+                        "language":null,
+                        "blockType":"text",
+                        "text":"I had no background in any Native American languages prior to this experience, so this class provided many difficult challenges. I did what I could to fully engage in the course, and reaped many rewards through this venture. To this day, I continue to learn new things in the Apache language, and it allows me to more richly connect with the people of the San Carlos Apache Tribe. Among the Tribe, I have been blessed with many friends, who have helped me along the way. Ahíyi’e! (Thank you!)","heading":"Continuing the Journey"
+                    }
+                ],
+                "title":"Taking a Class in Apache Language (Nṉee Biyáti’)",
+                "author":"Kenneth Chan",
+                "tags":
+                [
+                    "apache",
+                    "language",
+                    "personal",
+                    "learning",
+                    "reflection"
+                ]
+            }
+        },
+        "storyExample": {
+            "type": "story",
+            "value": {
+                "published": true,
+                "id": "storyExample",
+                "title": "The Story Builder how-to",
+                "content": [{
+                    "heading": "Add Content Blocks",
+                    "blockType": "text",
+                    "text": "The Story Builder is designed based on building blocks. There are four types of blocks you can use to build your story:\n\n1. Written content—type directly in the tool\n2. Images (photos of items, drawings, diagrams, etc.)—capture photos or upload files\n3. Audio (sound)—record audio or upload files\n4. Video (audio and visual)—record video or upload files\n\nTo add content blocks and start creating your story, click on an icon at the top of the Story Builder to add a block. You can add as many blocks as you like."
+                },
+                {
+                    "heading": "Reorder Content Blocks",
+                    "blockType": "text",
+                    "text": "You can reorder your content blocks using the mouse or keyboard as follows.\n#### Mouse/Touch\n* Select and drag the block handle to move a block. You will see an insertion line appear at the position where the block will be relocated. To leave the block in the same position, move it until the insertion line is immediately above or below the block you’re moving.\n* Select the up/down buttons to move a block one position up or down.\n#### Keyboard\n* With focus on the up/down buttons, select enter or spacebar to move a block one position up or down, or\n* Use keyboard shortcuts to move a block up or down as follows:\n  * With focus on the whole block, use the up/down arrow keys on your keyboard together with Shift-Control (Mac) or Control/Ctrl (Windows) to move the block up or down."
+                },
+                {
+                    "heading": "Navigating through Content Blocks",
+                    "blockType": "text",
+                    "text": "You can use the up/down arrow keys on your keyboard to move focus from block to block.\n\n**Note:** focus must be on the whole block in order to use this keyboard control (rather than on any one element within the block). We are working on fixing a bug in the tool that limits the ability to move focus from block to block with the keyboard. See Current Bugs section for more detail."
+                },
+                {
+                    "heading": "Remove Content Blocks",
+                    "blockType": "text",
+                    "text": "To remove a content block from your story, first select the checkbox at the top right corner of each block and then click on the trash can icon on the top right corner of the Story Builder Tool. Note that deleted blocks cannot be retrieved."
+                },
+                {
+                    "heading": "Add Descriptions (Metadata) to Content Blocks",
+                    "blockType": "text",
+                    "text": "Each block you add to your story includes a few extra text fields where you can enter additional information about the content of that block. This optional information is called ‘Metadata’ and it helps screen readers, search engines and other assistive technologies find and access the content of each block."
+                },
+                {
+                    "heading": "Embedding links with markdown",
+                    "blockType": "text",
+                    "text": "The Story Tool supports the use of markdown (for example, refer to the [Github Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#links)). Markdown can be used in the text content of a text block, or in the heading or description fields of any story block (i.e. text, image, video, audio). You are free to use it in any way you wish, in any of these fields.\n\n\nFor our purposes here, we describe how to embed a link into text content using markdown, since this is currently the only way to embed a link in your story. We are working on more user-friendly ways of adding links, and your feedback and ideas are welcome!\n\n\nTo create a link, the **link text** (what the reader will see and select) is put in square brackets, followed by the **link address** in round brackets, with no space between them, like so:\n\n\n`[Learn more about the IDRC](https://idrc.ocadu.ca/)`\n\n\nWhich will appear as:\n[Learn more about the IDRC](https://idrc.ocadu.ca/)\n\n\nAdditionally, you can add a **link title** in quotes following the link address, which in some browsers will appear on hover, and will be read by screen readers. This can help give your readers a better idea of where the link is going to take them. In this example, “IDRC Website” is the title. Be sure to include a space between the link address and the title, like so:\n\n\n`[Learn more about the IDRC](https://idrc.ocadu.ca/ \"IDRC Website\")`\n\n\nWhich will appear in your story as:\n[Learn more about the IDRC](https://idrc.ocadu.ca/ \"IDRC Website\")\n\n\n[This article by the Nielsen Norman Group](https://www.nngroup.com/articles/title-attribute/ \"Using the Title Attribute to Help Users Predict Where They Are Going\") describes the use of link titles in detail."
+                },
+                {
+                    "heading": "Add Story Title, Author Name and Keywords",
+                    "blockType": "text",
+                    "text": "When you've added all the blocks to your story, select “Continue” to give your story a title, author name and some keywords. This information helps others find your story and attribute it to you when they are reusing it. If you plan to enter several keywords, make sure they are separated by a comma."
+                },
+                {
+                    "heading": "Preview Story",
+                    "blockType": "text",
+                    "text": "Selecting the “Preview My Story” button will display your story as it will appear when published. You can always select the “Back” button to go back to the previous section and continue editing your story."
+                },
+                {
+                    "heading": "Publish Story",
+                    "blockType": "text",
+                    "text": "Once you are ready to publish your story on The Storytelling Project website, you can select the “Publish My Story” button. Please note that published stories are licensed under Creative Commons Attribution BY 4.0. This means others can reuse the content, make modifications, and attribute to the original author. Published stories are not editable and you cannot remove them from the site.\n\nIf you wish to remove your story from the website, please send an email to the address listed on the footer to request removal of your story."
+                },
+                {
+                    "heading": "Saving Your Story",
+                    "blockType": "text",
+                    "text": "A draft of your story is saved automatically as you work. Text entered into an active text field will not be saved until you navigate out of that text field.\n\nIf you close the Story Tool browser window without publishing your story, your draft will be loaded the next time you open the story tool, as long as you are using the same browser on the same device. At the moment, files (such as videos, images or audio clips) will not be saved with your story, so you will have to add them back in again after loading your story (see Currently Known Bugs section)."
+                },
+                {
+                    "heading": "Browse Stories",
+                    "blockType": "text",
+                    "text": "Select the “Browse Stories” button to browse through a collection of published stories by various contributors."
+                },
+                {
+                    "heading": "Currently Known Bugs",
+                    "blockType": "text",
+                    "text": "Thank you for your patience as we work on improving the Story Tool! Any feedback you can provide is very helpful. You can contact us at stories@idrc.ocadu.ca.\n#### Keyboard focus\n* Using the keyboard to navigate through the Story Builder, you will notice that when focus lands on the first block it encompasses all the buttons as well as the editable block fields.\n* This allows you to navigate from block to block using your keyboard up/down arrow keys, and to reorder your blocks using keyboard shortcuts (see Reorder Content Blocks section for more details).\n* At the moment, however, tabbing from one block to another will not move focus to the whole block, rather it will move focus to the first element within the block.\n* In addition, Shift-tab will not move focus to the whole block.\n* Currently, to focus the whole block, the author must use the keyboard to navigate back to the delete key and then back into the story edit area, or select the desired block using the mouse (mouse click in the upper bar of the block, or on the reorder handle).\n#### Up/down reorder buttons activation\n* The up/down reorder buttons on a newly added block will remain inactive until focus lands on any story block. To focus on a block, you can click/touch anywhere within the block or navigate to it with the keyboard.\n#### Auto-saving\n* At the moment, files (such as videos, images or audio clips) will not be saved with your story. If you close the Story Tool and return, only the text content of your story will be reloaded. You will have to add them back in again after loading your story.\n* Text entered into an active text field will not be saved until you navigate out of that text field.\n"
+                }],
+                "author": "IDRC",
+                "tags": [
+                    "Help",
+                    "Example",
+                    "How-to"
+                ]
+            }
+        }
+    }
+});

--- a/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/aihec_stories_0.3.0_to_0.4.0_migration.js
+++ b/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/aihec_stories_0.3.0_to_0.4.0_migration.js
@@ -1,0 +1,68 @@
+/*
+For copyright information, see the AUTHORS.md file in the docs directory of this distribution and at
+https://github.com/fluid-project/sjrk-story-telling/blob/main/docs/AUTHORS.md
+
+Licensed under the New BSD license. You may not use this file except in compliance with this licence.
+You may obtain a copy of the BSD License at
+https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.txt
+*/
+
+// These eslint directives prevent the linter from complaining about the use of
+// globals or arguments that will be prevent in CouchDB design doc functions
+// such as views or validate_doc_update
+
+/* global sjrk, emit, newDoc, oldDoc, userCtx, secObj */
+/*eslint no-unused-vars: ["error", { "vars": "local", "argsIgnorePattern": "newDoc|oldDoc|userCtx|secObj" }]*/
+
+"use strict";
+
+require("infusion");
+fluid.setLogging(true);
+var sjrk = fluid.registerNamespace("sjrk");
+
+require("../../singleNodeConfiguration");
+require("./aihec_stories_0.3.0_to_0.4.0_documents");
+
+
+// Mix-in grade for all the couch configuration
+// components when actually used to configure
+// the DB
+fluid.defaults("sjrk.storyTelling.server.dbSetup.core", {
+    distributeOptions: [
+        {
+            target: "{that}.options.couchOptions.couchUrl",
+            record: "@expand:kettle.resolvers.env(COUCHDB_URL)"
+        },
+        {
+            target: "{that}.options.components.retryingBehaviour.options.retryOptions.maxRetries",
+            record: "@expand:kettle.resolvers.env(COUCHDB_CONFIG_MAX_RETRIES)"
+        },
+        {
+            target: "{that}.options.components.retryingBehaviour.options.retryOptions.retryDelay",
+            record: "@expand:kettle.resolvers.env(COUCHDB_CONFIG_RETRY_DELAY)"
+        }
+    ],
+    listeners: {
+        "onCreate.configureCouch": "{that}.configureCouch"
+    }
+});
+
+// sets up a new instance of the core setup along with replicatorDb defined
+sjrk.storyTelling.server.replicatorDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with usersDb defined
+sjrk.storyTelling.server.usersDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with globalChangesDb defined
+sjrk.storyTelling.server.globalChangesDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with the storiesDb defined
+sjrk.storyTelling.server.storiesDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});

--- a/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/cities_stories_0.3.0_to_0.4.0_documents.js
+++ b/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/cities_stories_0.3.0_to_0.4.0_documents.js
@@ -1,0 +1,1473 @@
+/*
+For copyright information, see the AUTHORS.md file in the docs directory of this distribution and at
+https://github.com/fluid-project/sjrk-story-telling/blob/main/docs/AUTHORS.md
+
+Licensed under the New BSD license. You may not use this file except in compliance with this licence.
+You may obtain a copy of the BSD License at
+https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.txt
+*/
+
+// These eslint directives prevent the linter from complaining about the use of
+// globals or arguments that will be prevent in CouchDB design doc functions
+// such as views or validate_doc_update
+
+"use strict";
+
+require("infusion");
+require("kettle");
+
+require("fluid-couch-config");
+
+// sets up the Storytelling Tool database migration using fluid-couch-config
+fluid.defaults("sjrk.storyTelling.server.storiesDb", {
+    gradeNames: ["fluid.couchConfig.pipeline.retrying"],
+    couchOptions: {
+        dbName: "stories"
+    },
+    listeners: {
+        "onSuccess.logSuccess": "fluid.log(SUCCESS)",
+        "onError.logError": "fluid.log({arguments}.0.message)"
+    },
+    dbDocuments: {
+        "02067af0-d68e-11e9-878e-13cc3403c489":
+        {
+            "type": "story",
+            "value": {
+                "id": "02067af0-d68e-11e9-878e-13cc3403c489",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "It was a cool and sunny winter day. James was going to the store to buy Cheezies to take to his seniors club but today’s trip is not like a regular day, because he has a cast on his left arm. Luckily for James he was right-handed. It was still tricky for him to get around with his cane. But today, James was determined to go outside and get what he needed for his new seniors club. James was not sure what he was getting himself into with this shopping trip but he was willing to give it a try and see what it was like shopping with a cast. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl":"./uploads/02023530-d68e-11e9-878e-13cc3403c489.jpeg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568377436000,
+                            "name": "city.jpeg",
+                            "size": 14221,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "James grabbed his backpack and put it over his shoulder a bit clumsily. \nJames left his apartment, slamming his door behind him. “It drives me up the wall that I have to balance my cane and bag with this bum arm. That stupid driver! If he had just waited until I had sat down before moving, none of this would have happened. I wouldn’t have fallen and broken my arm.” Unfortunately, it happened all the time that the bus driver would drive off in a rush. James wished that there was a signal to let the driver know when he was safely seated. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl":"./uploads/02025c40-d68e-11e9-878e-13cc3403c489.jpeg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568377436000,
+                            "name": "button.jpeg",
+                            "size": 7993,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "After walking for a block, James began to calm down. He felt like he belonged because this was his neighbourhood. He saw people that he knew and started to feel better. He felt that he was getting all the garbage out of his mind. James arrived at the store in a better mood. He enjoyed coming to the store because he knew what it was all about. He could go out and get what he wanted all by himself and he liked that experience. It was so nice that the store was near James’ home. He could go whenever he wanted. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl":"./uploads/02028350-d68e-11e9-878e-13cc3403c489.jpeg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568377436000,
+                            "name": "store.jpeg",
+                            "size": 20447,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "James always felt that he could be independent at this store because it had a railing on both sides of the entrance so he felt secure on the step and he knew where his favorite foods were. However, today James is buying Cheezies, which is something new and he doesn't know where to find it. James looked for a friendly face and spotted his favorite cashier. He asked her for help and she was happy to help him to buy Cheezies. The cashier even helped James puts the Cheezies in his bag. It’s hard to manage a zipper with one hand and keep his cane from falling. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "mediaUrl":"./uploads/blob:https://stories.cities.inclusivedesign.ca/8441ef09-1cf2-0c4f-8afa-2b094f668f0c",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568377436000,
+                            "name": "cheesies.jpeg",
+                            "size": 6278,
+                            "type": "image/jpeg"
+                        },
+                        "text": "On the way home, James glances at his watch and realises that he’s running late. “Oh no, I booked Wheel Trans for 1:00” James had to be at the front of his building on time because Wheel Trans would not wait and if he missed it he wouldn’t get to go. James hurried home but had to be careful because it was winter and the sidewalks could be slippery. “It's not the ice you see that you have to worry about,” James muttered to himself. James arrived at the front of his building, “made it!” James felt relief. Despite the blue sky it’s chilly so James decides to wait in the foyer. “Ah, that’s better.” James let the warmth from the heater take the chill off. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "James keeps a close out the door as he waits and waits and waits. James glances at his watch, and waits some more. Finally, at 1:40, Wheel Trans arrived. “I wish I could take the bus like I used to but it just isn’t safe anymore.” James felt anger at the driver for being so late but he smiled anyway and was polite because he might get the driver again and he relies on the driver and doesn’t want to get in his bad books. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "text": "James keeps a close out the door as he waits and waits and waits. James glances at his watch, and waits some more. Finally, at 1:40, Wheel Trans arrived. “I wish I could take the bus like I used to but it just isn’t safe anymore.” James felt anger at the driver for being so late but he smiled anyway and was polite because he might get the driver again and he relies on the driver and doesn’t want to get in his bad books. ",
+                        "mediaUrl":"./uploads/0202aa60-d68e-11e9-878e-13cc3403c489.jpeg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568377436000,
+                            "name": "bus.jpeg",
+                            "size": 9510,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "mediaUrl":"./uploads/blob:https://stories.cities.inclusivedesign.ca/74941cdb-0abc-794b-b098-9f1d1c82a613",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568377436000,
+                            "name": "bus.jpeg",
+                            "size": 9510,
+                            "type": "image/jpeg"
+                        },
+                        "text": "Safely on his way to the senior’s club at the community centre, James lets the frustration of the wait go and begins to feel excited about getting out. James had been to seniors club a few times and he liked going but he was still feels like the new person and, so he is a little nervous too. Today is the first time Jame is going to the club without Anib, his support worker. James thought Anib was the friendliest person he had ever met. Anib knew James’ interests and helped him find the seniors club to join. Anib also gave James the support that he would need to get to the club, meet the coordinator and feel comfortable getting to know the other members. Anib helped him find his way around and know where things are. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "James had really missed people since he retired from his job and he missed his responsibilities of helping out and giving back to the community. He was an expert at what he did and had enjoyed every minute of it. This senior’s club was a chance for James to meet new people and to have a new responsibility and a role. This week, James is part of the food committee and has the job of helping to organize the snacks. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "text": "James had really missed people since he retired from his job and he missed his responsibilities of helping out and giving back to the community. He was an expert at what he did and had enjoyed every minute of it. This senior’s club was a chance for James to meet new people and to have a new responsibility and a role. This week, James is part of the food committee and has the job of helping to organize the snacks. ",
+                        "mediaUrl":"./uploads/0202d170-d68e-11e9-878e-13cc3403c489.jpeg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568377434000,
+                            "name": "seniors club.jpeg",
+                            "size": 13443,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "mediaUrl":"./uploads/blob:https://stories.cities.inclusivedesign.ca/8dfa12b8-765c-3a44-906f-a1b2214e6620",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568377434000,
+                            "name": "seniors club.jpeg",
+                            "size": 13443,
+                            "type": "image/jpeg"
+                        },
+                        "text": "It was great that the seniors had their own space within a larger community centre. They had a room just for them and for their things but could see all the different activities around them, kids and parents, newcomers learning English, young people exercising. There was a lot going on all the time but, in their space, things were slower- paced and quieter. The room was just for them and everything that they needed was in that one spot. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "When James arrived at the senior’s club, he began to set up the food table and along came Wally. Inwardly, James sighed. Wally was never happy unless he was telling people what to do. “Don’t put the Cheezies in the chip bowl. “ Wally sniped. James wanted to say, “Cheezies, chips what’s the difference?” but talking to Wally was like talking to a wall. “Perfect name,” thought James, he didn’t feel safe with Wally and wondered why Wally couldn’t be friendly. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "text": "When James arrived at the senior’s club, he began to set up the food table and along came Wally. Inwardly, James sighed. Wally was never happy unless he was telling people what to do. “Don’t put the Cheezies in the chip bowl. “ Wally sniped. James wanted to say, “Cheezies, chips what’s the difference?” but talking to Wally was like talking to a wall. “Perfect name,” thought James, he didn’t feel safe with Wally and wondered why Wally couldn’t be friendly. ",
+                        "mediaUrl":"./uploads/0202f880-d68e-11e9-878e-13cc3403c489.jpeg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568377436000,
+                            "name": "cheesies.jpeg",
+                            "size": 6278,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl":"./uploads/0202f881-d68e-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568377434000,
+                            "name": "men arguing.jpg",
+                            "size": 55808,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "James looked for the Cheezie bowl but had know idea which bowl would keep him out of trouble with Wally so he turned to the activities coordinator, Mary, who was always willing to help people who need help. Mary helped James with the bowl and thought about the problem James’ discomfort with Wally and Wally’s need to have everything just so. Mary knew from her meetings with Anib that James was a good listener and enjoyed hearing about everyone’s day. Mary asked James to lead the group in sharing their stories from the past week. James was good at making everyone feel comfortable and listened well. He made people feel heard. Even Wally was willing to share his stories. James and Wally realised that they had some things in common. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "After story-sharing, Mary suggested that James and Wally work together to label the cupboards and the things inside so that everyone would know where everything goes and what each thing is for. James is really good at drawing and he uses pictures to help label the bowls and Wally prints neatly so he writes all of the words. From that day on, everyone could know which bowl was for Cheezies and which was for chips. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl":"./uploads/020346a0-d68e-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568377434000,
+                            "name": "cupboard edited.jpg",
+                            "size": 26636,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "title": "Jame's Story",
+                "author": "",
+                "tags": []
+            }
+        },
+        "11ccefa0-d64d-11e9-878e-13cc3403c489":
+        {
+            "type": "story",
+            "value": {
+                "id": "11ccefa0-d64d-11e9-878e-13cc3403c489",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Starting the Day",
+                        "blockType": "text",
+                        "text": "My guide dog and I start our morning with a walk by the lake. This is a favourite\nspot because the boardwalk is wide and the white benches and handrails stand\nout against the background. I enjoy the soft sound of the waves and birds and\nthe feeling of being with nature. This is a calming space for me as I get ready for\nthe day ahead. I have a hearing loss as well as being legally blind so these\nmoments of quiet are important to me."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/11c108c0-d64d-11e9-878e-13cc3403c489.JPG",
+                        "alternativeText": "People-friendly street.",
+                        "description": "People-friendly street.",
+                        "fileDetails": {
+                            "lastModified": 1568396004360,
+                            "name": "IMG_0886 - Copy.JPG",
+                            "size": 524777,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/11c2dd80-d64d-11e9-878e-13cc3403c489.JPG",
+                        "alternativeText": "Boardwalk by the lake.",
+                        "description": "Boardwalk by the lake.",
+                        "fileDetails": {
+                            "lastModified": 1568395977574,
+                            "name": "IMG_0894 - Copy.JPG",
+                            "size": 893146,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Heading Downtown",
+                        "blockType": "text",
+                        "text": "I am heading to downtown Toronto for a professional conference. I head to my\nlocal GO train station with my guide dog and we meet up with my human\ncompanion. I’m thankful for the portable ramp onto the accessible train car. It’s\neasier as the steps are hard to navigate."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "When we disembark at Union Station, we make our way to the elevator. I’m not\nable to see the buttons on the panel, even though it has red backlighting. It is\nnot enough contrast for me to see. I have to wait for someone else to push the\nbutton. The Braille buttons are a nice \"feel good\" feature for those who are\nsighted or blind (if the blind can find it...). Not many low vision persons know\nBraille."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "When we get off the elevator, we are now in what I call “chaos,” with people\nrushing in every which direction. My companion struggles to find the sign to the\nstreet because the station has changed so much recently. The environment at\nUnion is constantly changing due to the ongoing renovations. This makes it\nconfusing to find our way around."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/11c54e80-d64d-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Go Train",
+                        "description": "GO Train",
+                        "fileDetails": {
+                            "lastModified": 1568396030657,
+                            "name": "cover_photo_26_0.jpg",
+                            "size": 52205,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "On the Streets",
+                        "blockType": "text",
+                        "text": "We finally make our way to street level. The constant sounds of traffic (trucks are the worst!), construction noise, and people talking all blend into a cacophony of sound. It is hard to hear my companion so conversation is not easy. Waiting at an intersection for our light to turn green, a wide-bodied truck makes a right turn in front of us. My companion pulls me back a few feet to avoid contact with the truck body and wheels. What seems like numerous encounters with construction hoardings has us veering off to the right or left to walk along the temporary wood surface. These tactile changes my feet felt, combined with the construction noises, do not feel safe."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Navigating Steps",
+                        "blockType": "text",
+                        "text": "I arrive at the conference venue feeling very stressed. This is not helped by the fact that I almost fell down the stairs when making my way to the correct floor amid a crowd of other conference-goers. The stairs don’t have a continuous handrail and there are no tactile markings on the floor. I don’t know where the stairs begin and end. A ramp would have been better!\n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Dinning Out",
+                        "blockType": "text",
+                        "text": "After the last panel at the conference, a group of colleagues and I decide to continue the discussion at a nearby restaurant. The restaurant website indicates that it is accessible. On the way to the restaurant, I look for an area to relieve my dog. I know she has to go, but there is only concrete. All of a sudden, my dog stops smack in the middle of a sidewalk and has a poop. I always travel with (empty!) poop bags so I pick it up. It is a while before my companion points out a garbage can and I deposit it. This is not the first time my dog has dumped on the sidewalk. (Hint to neighborhood designers and developers: please provide obvious relief areas for service and pet animals. Could be as simple as a large square of dirt next to a curb side tree and a garbage can next to it.)"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "The hostess at the restaurant is putting tables together to accommodate our large group. We explain to the hostess we need a table with a bright light because of my low vision. But once we’re seated, I find it’s not bright enough for my needs. I ask if the lights can be turned up and the answer is no. The noise level of music and people talking and dishes/glasses clinking is loud and it is hard to have a conversation with anybody. We are handed menus and I put mine aside. The server comes to our table and starts talking rapidly. \"Hi, my name is ? And I am your server tonight. The specials are blah blah blah ...... And comes with blah blah blah. And the soup is blah blah blah. Can I get you something to drink?\""
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I have no clue what the specials are as it was too noisy to hear and too fast to follow. By now, YES, I need a drink! I order my usual as it's a standard drink. My companion tells me slowly and clearly what the specials are. We order our food. When it arrives, I cannot figure it out. My companion is accustomed to telling me things like: the potatoes are at 6 o'clock, the meat is at 9 o'clock, etc. This time, however, he looked flummoxed. The menu did not describe this as a DIY (do it yourself) assembly dish. This was a lettuce wrap that I had to put together myself from a literal head of lettuce. It was definitely not \"blind friendly\". The waiter came over and explained how to put it together for EACH bite. I could not see to do this so ended up picking away at the individual ingredients. Not enjoyable."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Meanwhile, the noise level is getting to me. If I turn the hearing aids down it is hard to hear the people around me. If I leave the hearing aids alone, it is still difficult. I’m missing all the jokes and stories people are sharing with one another. The connections that they are making is something I am not a part of. Watching my fellow group members interact and not being able to participate makes me feel isolated. I’m not enjoying this, I’m enduring it. I can’t wait for the meal to end."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/11c5eac0-d64d-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Busy restaurant.",
+                        "description": "Busy restaurant.",
+                        "fileDetails": {
+                            "lastModified": 1568396055438,
+                            "name": "here-is-the-restaurant.jpg",
+                            "size": 55877,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Using the Washroom",
+                        "blockType": "text",
+                        "text": "I need to use the washroom before we leave. As I bump my way past tables that are too close together, I reflect that this is not a wheelchair friendly space as well as not low vision or hard of hearing friendly. The washroom is dimly lit. The stall doors and partitions are dark and so are the walls of the room. I finally spot a white toilet and use it. The sink and soap are manageable although finding the dark paper towels and garbage can is a challenge. And the door to get out of the washroom is the same color as the walls. Finally, I see the glint of a metal handle on the door and open it."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Home Sweet Home",
+                        "blockType": "text",
+                        "text": "When I get home, I realize how tense my shoulders are. I feel drained from the challenging day I just had. Home sweet home!"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/11c638e0-d64d-11e9-878e-13cc3403c489.JPG",
+                        "alternativeText": "Dirt path near water and trees.",
+                        "description": "Dirt path near water and trees.",
+                        "fileDetails": {
+                            "lastModified": 1568395911853,
+                            "name": "IMG_0897.JPG",
+                            "size": 2454393,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "title": "Into the Chaos",
+                "author": "",
+                "tags": [
+                    "hard of hearing",
+                    "low vision",
+                    "accessibility",
+                    "way\u0000nding",
+                    "cities"
+                ]
+            }
+        },
+        "232dabb0-d501-11e9-b489-e9b807f15c0e":
+        {
+            "type": "story",
+            "value": {
+                "id": "232dabb0-d501-11e9-b489-e9b807f15c0e",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "",
+                        "blockType": "text",
+                        "text": "My daily commute in the city is pretty intense. While walking too and from the subway to my destination, I am constantly reminded of the city’s homeless crisis with the increasing number of men and women sheltering on the street. The city needs a sustainable solution to better accommodate people in less fortunate situations, but part of the problem is the increasing housing prices in Toronto. Since cost of living the city is so high, many people live around Toronto and depend on the transit system to get to work. In the Toronto transit, the mornings around 9 am and in the afternoon at 5pm, it get's extremely crowded underground. I usually have to wait for a couple of full cars to pass me before I can get on the subway. With so many people working downtown that don't live here, the commute is becoming more and more packed. Since the population is increasing, but the transportation system is remaining the same, the only solution would be to have a greater number of subways running. However, that's not easily done. It would take years, for adaptation, so for the time being, that just means a longer commute time. Now adding on top of that, is the fact that there are only two main underground lines. Line1 and Line 2. If theres a delay, it affects EVERYONE. Someone may have called for assistance at College Station, that would then cause delays on the entire Line 1. In the summer, when there is added body heat, and delays occur underground, it is an absolute nightmare. One time around 5:14 my train on Line 1 got stuck underground. For the next 20 min there was a gradual rise in panic. People started feeling claustrophobic and someone even fainted."
+                    }
+                ],
+                "title": "A Day in Toronto",
+                "author": "Zoya, Nahin & Tania",
+                "tags": [
+                    "toronto",
+                    "transit",
+                    "commute",
+                    "subway",
+                    "housing",
+                    "underground",
+                    "city"
+                ]
+            }
+        },
+        "3b5d85b0-d4fd-11e9-b489-e9b807f15c0e":
+        {
+            "type": "story",
+            "value": {
+                "id": "3b5d85b0-d4fd-11e9-b489-e9b807f15c0e",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "PI is an active individual who likes to ride bicycle. He generally doesn't ride in downtown area and he is not very familiar with the environment. While riding bike he drinks plenty of water to keep himself hydrated in hot weather. However, drinking lot of water makes him go to the washroom frequently. On a very hot day, PI is exploring the downtown area on his bike and he comes across the intersection where there is no traffic light to cross the street. He finds it very confusing and in a hurry he tries to cross the street light and he almost got hit by a tour bus. This sudden incident startles him and he became very nervous. He drank the last drop of water out of his bottle. He parked his bike , locked it and wanted to find a drinking fountain at nearby shopping mall. He finds the Eaton centre and at the entrance he found the washroom which is fully occupied. \n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "He tries to locate the next available washroom and it was towards the very end of the shopping mall. It's quite a long distance and he rushed towards the washroom but realised it's only female washroom. Mens' washroom was available downstairs. Instead of going downstairs he uses the disabled washroom. He goes back to the area where he had parked the bike but by the time he got there the bike was stolen. \n"
+                    }
+                ],
+                "title": "Life of PI",
+                "author": "Erman, April and Apala",
+                "tags": [
+                    "bike",
+                    "washroom",
+                    "drinking fountain and traffic light"
+                ]
+            }
+        },
+        "9e2d0b30-d4fc-11e9-b489-e9b807f15c0e":
+        {
+            "type": "story",
+            "value": {
+                "id": "9e2d0b30-d4fc-11e9-b489-e9b807f15c0e",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "",
+                        "blockType": "text",
+                        "text": "Steve, a blind man living in a basement who is sensitive to everything except vision. He wants to avoid bad smells and sounds and get where he's going precisely so he has to plan routes.\n\nSteve wakes up and he can smell yesterday's dinner and it depresses him. Last night, he ate pizza and the smell lingers. The sound of the construction outside penetrate through the walls. He can also hear the streetcars bumping along the line constantly and shaking his building. This has caused him to not get enough sleep. He feels like a zombie. The second floor above has three cats living in the building and they've been running around all night."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/9e2a2500-d4fc-11e9-b489-e9b807f15c0e.jpg",
+                        "alternativeText": null,
+                        "description": "A picture of stinky pizza from yesterday's dinner.",
+                        "fileDetails": {
+                            "lastModified": 1568250963448,
+                            "lastModifiedDate": "2019-09-12T01:16:03.448Z",
+                            "name": "65130590_2283313075091979_2114667185870733312_n.jpg",
+                            "size": 96332,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Steve has to get to a job interview at 9:00am. He smells some pizza on his shirt. Once he leave his basement apartment, and smells fresh air, he notices that even his clean clothes smell like pizza. He has to search for the interview location on his phone, but he's got a headache because of the lack of sleep and noise. At least the pizza was good. I guess. Oh no, Steve is late for his interview. He kind of knows the area well, but there's construction that just started today so there's temporary fences and walls everywhere disorienting him."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/9e2a7320-d4fc-11e9-b489-e9b807f15c0e.jpg",
+                        "alternativeText": null,
+                        "description": "A picture of construction.",
+                        "fileDetails": {
+                            "lastModified": 1568250974711,
+                            "lastModifiedDate": "2019-09-12T01:16:14.711Z",
+                            "name": "70508084_2845090525504421_2525775137546960896_n.jpg",
+                            "size": 40290,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Steve asks someone on the street for directions, but the construction noise is too loud and couldn't understand the directions so he goes in the wrong direction. The person helping him is really nice and helps Steve to the building. But before they reach the entrance, they have to leave. And that's why Steve had to spend twenty more minutes looking for the door."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/9e2ac140-d4fc-11e9-b489-e9b807f15c0e.jpg",
+                        "alternativeText": null,
+                        "description": "A picture of the bank Steve is applying for a job.",
+                        "fileDetails": {
+                            "lastModified": 1568251116386,
+                            "lastModifiedDate": "2019-09-12T01:18:36.386Z",
+                            "name": "70016853_2493778924183222_7067196053652504576_n.jpg",
+                            "size": 59025,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Then he goes in and realizes, the washroom is really smelly. He goes into the elevator and there's no audio feedback for the doors. Steve questions his life. Does he want this job?"
+                    }
+                ],
+                "title": "The Day That Makes You Ask Why...",
+                "author": "Alis Panja, Steve Murgaski, Nikkie To",
+                "tags": [
+                    "blindness",
+                    "smell sensitivity",
+                    "noise sensitivity"
+                ]
+            }
+        },
+        "b7b40610-d67f-11e9-878e-13cc3403c489":
+        {
+            "type": "story",
+            "value": {
+                "id": "b7b40610-d67f-11e9-878e-13cc3403c489",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I was driving into the parking lot and parked in a designated wheelchair parking. When I went to pay I realized it was rather difficult due to non-adjustable parking meter. From my angel seated in my wheelchair, the glare from the lights above me made it difficult for me to see the screen. The number to call for assistance went straight to voicemail. I left a voicemail with my license plate and cellphone number and stated that the machine was not reading my credit card. Digital options were simply not working, and I desperately needed a more human connection for assistance."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/b7af7230-d67f-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Paid parking sign with instructions and contact information",
+                        "description": "Paid parking sign with instructions and contact information. \nSign that reads: Private Property, Pay Parking, Patrolled and Enforced 24 Hrs a Day. If you park and do not display a valid ticket or permit, the rate it $65.75?day or portion thereof. In addition, your vehicle may be subject to being ticketed and/or towed at owner's expense. t. 647.503.6006 www.go-parking.com LOT#G010",
+                        "fileDetails": {
+                            "lastModified": 1568376584000,
+                            "name": "pay parking.jpg",
+                            "size": 65588,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/b7afc050-d67f-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": null,
+                        "description": "Parking payment method.\n\nShowing where to insert credit card or change for payment method on parking meter.\n",
+                        "fileDetails": {
+                            "lastModified": 1568376584000,
+                            "name": "Parking payment method.jpg",
+                            "size": 34457,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I walked into the grocery store using the specific entrance, and as I was perusing the aisles, I found that there were several staff hovering over me, when all I wanted was for someone to just say “I am here if you need me”. Once I was done getting everything I needed, I found my way to the accessible cashier lane, only to find it unstaffed. So then I went into a regular line, where a customer offered to assist me by taking the groceries out of my bag from the back of my chair onto the conveyor belt. The card reader was also not adjustable. It could not be moved and it was out of my reach, so it was impossible to be able to hide my personal information when I reached over. This was yet another awkward instance where I felt I did not have autonomy."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/b7afe760-d67f-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Shows non-portable card reader which glare from above lights.",
+                        "description": "Shows non-portable card reader which glare from above lights.",
+                        "fileDetails": {
+                            "lastModified": 1568376582000,
+                            "name": "non-portable card reader.jpg",
+                            "size": 72413,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "No staff assisted me; it was simply other shoppers that offered to help. Common empathy of the average person rather than the attentiveness of staff has been a recurring theme of my shopping experience. Without the kindness of strangers, I often find that advocating for myself in what are monitored public spaces increases the feeling of “invisibility”.\nOnce I was finished I decided to head into the Mall to use the accessible washroom. I found it to not be so accessible after all, as it was in fact also being used as a non-gendered and family washroom. The support handles were not adjustable, and the automatic door was not working making it much harder to open. There were many other non-accessible features of the washroom such as greatly elevated mirror that started at my forehead, as well as a hand dryer that blew into my face. The toilet seat was significantly lower than my wheelchair, which made it difficult to transfer over, as well as the support bar being too high."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/b7b03580-d67f-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Toilet seat is significantly lower than wheelchair.",
+                        "description": "Toilet seat is significantly lower than wheelchair.",
+                        "fileDetails": {
+                            "lastModified": 1568376584000,
+                            "name": "Inaccessible toilet seat.jpg",
+                            "size": 48695,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/b7b05c90-d67f-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Support bar above shoulder level.",
+                        "description": "Support bar above shoulder level.",
+                        "fileDetails": {
+                            "lastModified": 1568376584000,
+                            "name": "Support bar above shoulder level.jpg",
+                            "size": 53057,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Heading back to the grocery store, I started to realize that mall closure had already begun unannounced. I noticed that the accordion gate between the grocery store and the mall had been closed, so I looked for a security guard to ask for assistance. I communicated that I needed passage through the grocery store to get to where I parked."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/b7b083a0-d67f-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Entrance between mall and grocery store blocked by accordion gate.",
+                        "description": "Entrance between mall and grocery store blocked by accordion gate.",
+                        "fileDetails": {
+                            "lastModified": 1568376584000,
+                            "name": "Entrance blocked by accordian gate.jpg",
+                            "size": 94707,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "He said my only option was to leave through a different exit. This was concerning to me because it was a longer route and I was very tired at this point. I can see through the now closed barricade, other shoppers still using the store on the other side. The solution was simple. I explained to the guard that I needed to go through that exit to get to my vehicle. However, he was resistant. Another customer noticed me on the other side of the gate and approached customer service on my behalf. She was refused by customer service to address the situation. She came over to speak to me, and we discussed the unexpected early mall closure, which had left me feeling unwelcome and devalued as a customer. When she couldn’t find staff to help, she resorted to simply opening the gate herself and letting me through. No special knowledge was required, just compassion. Had this been a digitally timed locking device, this would not have been possible."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I exited the mall using the grocery store entrance and made my way to my parking space. There was a car double-parked between the designated wheelchair permitted spots. I was unable to leave until another compassionate person came along and offered to move my van so that I could open my automated door and extend the ramp for my wheelchair."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/b7b0d1c0-d67f-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Car double parked between two designated wheelchair accessible spots.",
+                        "description": "Car double parked between two designated wheelchair accessible spots.",
+                        "fileDetails": {
+                            "lastModified": 1568376584000,
+                            "name": "Car double parked in accessible parking spot.jpg",
+                            "size": 49691,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/b7b0f8d0-d67f-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Accessibility ramp being lowered to demonstrate appropriate space needed in between vans in parking spaces.",
+                        "description": "Accessibility ramp being lowered to demonstrate appropriate space needed in between vans in parking spaces.",
+                        "fileDetails": {
+                            "lastModified": 1568376584000,
+                            "name": "Accessibility ramp.jpg",
+                            "size": 66596,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Throughout my day I encountered several instances where getting around was difficult. Barriers to access is a common experience in my daily life and I am appreciative of the awareness and assistance of others when available. This proves that the human factor must remain in designing. When ignored it can affect all aspects of a person's physical, emotional psychological , and social interactions."
+                    }
+                ],
+                "title": "Human Factor",
+                "author": "",
+                "tags": [
+                    "accessibility",
+                    "compassion",
+                    "invisibility",
+                    "value",
+                    "consideration"
+                ]
+            }
+        },
+        "dabb6100-d67d-11e9-878e-13cc3403c489":
+        {
+            "type": "story",
+            "value": {
+                "id": "dabb6100-d67d-11e9-878e-13cc3403c489",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/daa60440-d67d-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Person crossing the street",
+                        "description": "",
+                        "fileDetails": {
+                            "lastModified": 1568376008000,
+                            "name": "1.jpg",
+                            "size": 1606385,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "My story is a story about finding a sense of place in Toronto. My journey as a queer refugee newcomer in Canada would lead me to new and unfamiliar spaces, and through moments when I felt completely alone and times when I felt at home with people I’d only just met. These experiences shaped who I am in a place that I knew nothing about at one point."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "The most important experiences for me were the ones that transpired in ordinary, everyday moments, in transitional spaces, and in quiet and small ways. The growing pains and struggles that came with these experiences would become an important part of my journey. They brought me to my community. They brought me home."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/daabf7b0-d67d-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Person standing on a background covered with different colors",
+                        "description": "",
+                        "fileDetails": {
+                            "lastModified": 1568376000000,
+                            "name": "2.jpg",
+                            "size": 2652404,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "A Desire to Belong",
+                        "blockType": "text",
+                        "text": "As a newcomer in Toronto, it was challenging to navigate the city layered with very different cultures, social norms and unspoken collective agreements shared between strangers. After landing here, I began to notice these differences, often with a debilitating level of acuteness and self-consciousness. In my culture, you are expected to seek out and utilize local knowledge when you are trying to navigate through a new or unfamiliar space; a sense of community is present even in public spaces and shared between strangers. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Here, in moments when I felt lost or confused and wanted to reach out to someone, I encountered apathy and occasionally even hostility. I come from a city that is far more complex and hard to navigate compared to Toronto. I have gotten lost several times while commuting, walking or driving in my city, but each time I was able to find my way with the help of strangers, which eased my anxiety. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/dab0b2a0-d67d-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Person crossing the street having thought bubbles",
+                        "description": "",
+                        "fileDetails": {
+                            "lastModified": 1568375998000,
+                            "name": "3.jpg",
+                            "size": 409464,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "As a newcomer in Toronto, I felt more isolated with each passing day knowing I was on my own if I were to get lost. It took me a while to process and understand the information in maps, signs, schedules, and wayfinders. Often, it overwhelmed me when I was experiencing confusion and anxiety. Language spoken feels more valuable than language read in such situations. The attitudes I encountered reminded me that I was far away from home."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/dab14ee0-d67d-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568376010000,
+                            "name": "4.jpg",
+                            "size": 1542779,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Searching...",
+                        "blockType": "text",
+                        "text": "It took me a few years to familiarize myself with this landscape and find spaces where I could connect meaningfully with people. I started working as a community facilitator, and through my practice, I began to connect with people through art and storytelling. Whether it was through poetry, art-making, craft or performance – the presence of art and artists in my everyday life, public spaces and within communities I am a part of made me feel accepted and comfortable to express who I am. I felt new spaces open up for me. I didn’t feel so lost anymore."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/dab3e6f0-d67d-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568376002000,
+                            "name": "5.jpg",
+                            "size": 1384796,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Kinship",
+                        "blockType": "text",
+                        "text": "Since coming out as queer woman, I had to learn, unlearn and relearn what kinship and family meant to me. As I think about this, my mind travels back to three years ago when I injured my shoulder in a bike collision. I developed chronic pain for which I sought out every kind of treatment I could find. With failing treatments, I had to come to terms with the reality of living with this pain. The permanent sensation of pain reminded me again that I was alone. The family that provided me with care and comfort when I was sick or in pain wasn’t here with me. All around me I saw people who didn’t have to live with pain every day and a culture that glorified physical fitness. The emotional experience of the pain was at times, worse than the physical one.\nBut my pain also gave me the tools to manage my pain in new and unfamiliar ways.\n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/dab630e0-d67d-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Person walking on a wooden path in the woods",
+                        "description": "",
+                        "fileDetails": {
+                            "lastModified": 1568375998000,
+                            "name": "6.jpg",
+                            "size": 1268749,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "In the following years, I sought and found alternative forms of care and healing. The only time I was able to forget about my pain was when I was walking in parks surrounded by old-growth trees, hiking in forests, sitting by the lake, feeding birds and studying trees. I felt myself growing closer and closer to my natural environment. Being near trees, whether in a park or backyard garden, soothed my pain, calmed my nerves and let me connect with something outside of myself. The kinship I developed with trees, birds, and animals not only healed me but made my connection to this place even stronger."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/dab79070-d67d-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Person standing in a small balcony on the second floor of a building",
+                        "description": "",
+                        "fileDetails": {
+                            "lastModified": 1568376004000,
+                            "name": "7.jpg",
+                            "size": 1393659,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Putting Down Roots...",
+                        "blockType": "text",
+                        "text": "My new life in this now familiar place needed a place that I could call home, one that I would be sharing with my partner. I try to forget how frustrating and arduous it was to look for a home as a young, queer POC (person of colour) couple. For a few months in the process, we had to live with the possibility of being forced to move to an area that was remote – disconnected from our support systems and friends. Luckily, we found a home in a tiny attic studio in a neighborhood that we love."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Looking back at these experiences, I can see how much I have grown in this city and how much the city has grown on me. My story is one of the many, many stories of the people from my newcomer, QTBIPOC community. It is what drives me to help others feel at home wherever they are."
+                    }
+                ],
+                "title": "The Way Home",
+                "author": "",
+                "tags": []
+            }
+        },
+        "e70890a0-d640-11e9-9605-5d78aa190f9a":
+        {
+            "type": "story",
+            "value": {
+                "id": "e70890a0-d640-11e9-9605-5d78aa190f9a",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "INTRODUCTION",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/e7027620-d640-11e9-9605-5d78aa190f9a.jpg",
+                        "alternativeText": "Top down shot of lightly coloured stones, different shapes and sizes.",
+                        "description": "Inclusiveness is like a precious stone. When someone comes across a precious stone, there are a number of different reactions they may have.\n\nThis story will present some of those reactions as scenarios, and describe how it relates to accessibility and inclusiveness.",
+                        "fileDetails": {
+                            "lastModified": 1568316201000,
+                            "name": "stream-stone-spring.jpg",
+                            "size": 104974,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "SCENARIO #1: NEGLECTING TO BE INCLUSIVE",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/e7029d30-d640-11e9-9605-5d78aa190f9a.jpg",
+                        "alternativeText": "Image of a desert, sand dunes",
+                        "description": "One way of reacting to the precious stone is outright dismissing it.\n\nThe Story:\nIn this scenario, the stone is completely ignored. Even though it has a shine, its own appeal, and characteristics, none of those are taken into account. The stone receives no attention and no value.\n\nImpact on Accessibility:\nThere are two different degrees of impact on accessibility: partial and total. \n\nTotal neglect involves no action towards accessibility. This creates stigma and discrimination towards accessibility. It also reinforces the blind spots that society may have about accessibility, making the issue even more challenging to resolve.\n\nPartial neglect occurs when you take some steps towards accessibility, but neglecting parts of it for different reasons. For example, a lack of funding or knowledge leads to partial neglect. Additionally, ignoring feedback on the existing solutions for accessibility also contribute to neglect.\n\nExamples:\n-\tA landlord that is solely interested in maximizing profit at the expense of the tenants. Despite being presented with the case for accessibility, the landlord outright dismisses these needs. Worse even, they use accessibility demands as a reason to divide tenants and make it difficult to find a solution for all.\n\n-\tUsing payment terminals that don’t enable a ”tap” functionality leads to privacy issues. Without a tap, a user has to share their pin with a third party (i.e. cashier) which puts their identity and security at risk.\n\n-\tBanks offer the service of a safety box, which are not designed to be accessible. Both the actual design of the infrastructure and the service itself are limiting and do not work for everyone ",
+                        "fileDetails": {
+                            "lastModified": 1568316476000,
+                            "name": "sand-dunes-1.jpg",
+                            "size": 367332,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "SCENARIO #2: INCLUSIVENESS AS A PROP",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/e703d5b0-d640-11e9-9605-5d78aa190f9a.jpg",
+                        "alternativeText": "Stones at the bottom of a clear glass, filled halfway with water, with plants coming out of glass",
+                        "description": "Another reaction to seeing a stone is to think about it as a prop or decoration. \n\nThe Story:\nIn this scenario, the stone is taken from its environment and used as a display piece. For example, this may add a certain aesthetic to someone’s home or serve as a decoration for his or her living space. In this scenario, the stone becomes part of the background; it’s not a focal point. It’s only brought up when it needs to be presented, but otherwise it’s sidelined as an object for display.\n\nImpact on Accessibility:\nHere, we see accessibility as a trend. It’s used as a real-world display piece to demonstrate compliance with legal requirements. This treatment puts more importance on the presentation of meeting accessibility (the superficial), not actually serving the core needs of accessibility (the meaningful).\n\nExample(s):\n-\tElevators that are designed to be accessible, but in fact do not meet the diverse needs of the users its intended to serve. The placement of the control panel is placed out of the hand range, the design of the buttons are limiting, a lack of voice-activated controls, etc.\n\n-\tWashrooms are not equipped with transferring devices for those in need. There is a range of unique, and private, needs that are unmet in washroom designs that don’t respect or dignify the users.",
+                        "fileDetails": {
+                            "lastModified": 1568317489000,
+                            "name": "46d7709ed59d5896540512978ced4034.jpg",
+                            "size": 84985,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "SCENARIO #3: INCLUSIVENESS AS A COMMODITY",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/e703fcc0-d640-11e9-9605-5d78aa190f9a.jpg",
+                        "alternativeText": "A full brick wall",
+                        "description": "Another reaction to seeing a precious stone, is to look at how you can use it to your own benefit. Essentially, the stone becomes an object of consumption.\n\nThe Story:\nFor example, the stone can be marketed, promoted, and sold. Driven by these motives, the stone is only valuable by serving the \"business\", not in its own right. The stone is just like any other stone, extracted from its environment and sold for its material benefit.\n\nImpact on Accessibility:\nThis relates to accessibility, because it's often valued from a commercialized or business perspective. This puts accessibility as risk of becoming commoditized. It downgrades the value of those with accessibility needs by dehumanizing the person. Both, the uniqueness and diversity found in inclusivity are removed in favour of efficiency and scale.\n\nExample:\nThe pricing and business model for a variety of accessible products and services demonstrate the commercialization of accessibility:\n-\tPower chairs that come at a price tag that is unreasonable for any individual to purchase, causing them to rely on funding or other means\n-\tAccessible tech and devices that are provided and serviced by organizations and \n-\tThe extremely high price point for accessible vans, and its maintenance at a specialized shops",
+                        "fileDetails": {
+                            "lastModified": 1568317625000,
+                            "name": "R10961_image1.jpg",
+                            "size": 103968,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "SCENARIO #4: CORE VALUE OF INCLUSIVENESS",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/e7044ae0-d640-11e9-9605-5d78aa190f9a.png",
+                        "alternativeText": "A rock with the inner layer exposed to reveal a multi-coloured gem",
+                        "description": "Another reaction to coming across the stone is to see, understand, and respect the stone for its own value.\n\nThe Story:\nIn this scenario, the stone is appreciated for its inherent value -- to know it as it is, not as you project. This means understanding all aspects of the stone like its history, environment, variety of characteristics, power of action and its limitations, etc.\n\nImpact on Accessibility:\nWhen it comes to accessibility, this reaction respects, dignifies, and empowers those served by inclusiveness. This involves seeking to understand the needs and challenges from the perspective of those who need it. Ultimately, this puts the focus on the real-life impact of accessibility and creates a habit of ongoing improvement. \n\nExample:\n-\tThe use of ramps in public spaces are an example of taking care of people’s needs\n- Closed Caption is a broad, mass, example of assisting those with hearing challenges",
+                        "fileDetails": {
+                            "lastModified": 1568317802000,
+                            "name": "4ce221c543c8ad90d44e2245e0aa08dc.png",
+                            "size": 378477,
+                            "type": "image/png"
+                        }
+                    }
+                ],
+                "title": "Grades and Shades of Inclusiveness",
+                "author": "",
+                "tags": [
+                    "inclusiveness",
+                    "accessibility",
+                    "experiences",
+                    "urban living",
+                    "planning",
+                    "infrastructure",
+                    "services",
+                    "transportation",
+                    "attitudes",
+                    "perceptions"
+                ]
+            }
+        },
+        "eaaf45f0-d64a-11e9-878e-13cc3403c489":
+        {
+            "type": "story",
+            "value": {
+                "id": "eaaf45f0-d64a-11e9-878e-13cc3403c489",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Starting My Day",
+                        "blockType": "text",
+                        "text": "I begin my day by waking up. My first prayer of the day is that my scheduled PSW shows up, which is unusual, most days I am left in bed until I can find someone to help me out. Today, she shows up. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Walking My Dog",
+                        "blockType": "text",
+                        "text": "Now that I am out of bed, and on my wheelchair and ready to go, I have to take my baby out. My baby’s name is Juba and he walks on four legs. So, I put my baby in his bag and took him to the park for about 45 mins. We head back home where I am going to leave Juba in a climatized environment as I’ll be gone for most of the day. I wish there was a way to access the thermostat in case it warms up or cools down during the day while Juba is at home. It would also be great to have a camera to watch him and maybe access to a community dog walker. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/ea979f40-d64a-11e9-878e-13cc3403c489.jpeg",
+                        "alternativeText": "Person on the wheelchair carrying a dog in a shoulder bag",
+                        "description": "Person on the wheelchair carrying a dog in a shoulder bag",
+                        "fileDetails": {
+                            "lastModified": 1568313169629,
+                            "name": "Dog in a bag.jpeg",
+                            "size": 1282601,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/ea9be500-d64a-11e9-878e-13cc3403c489.jpeg",
+                        "alternativeText": "Dog running in the park",
+                        "description": "Dog running in the park",
+                        "fileDetails": {
+                            "lastModified": 1568312773476,
+                            "name": "Juba.jpeg",
+                            "size": 761844,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Getting to Work",
+                        "blockType": "text",
+                        "text": "Back out ago hoping wheel trans will be on time to get me to work. GREAT! Wheel trans is here and I’m off to work. Sometimes wheel trans doesn’t even show up, or it can be up to one hour late, which means I get to work late, and I’ll be late for everything else during that day. It’s a good thing that my work can make accommodation for your tardiness. If the Wheeltrans doesn’t show up I should call the cap, which is very expensive, and it can add to a defect for my budget at the end of the month. Everything in Toronto is very expensive. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "At Work - Morning",
+                        "blockType": "text",
+                        "text": "Today at work, my morning is about giving a workshop on cultural competency, colonization and history of Canada, all the way to treat and reconciliation and working with indigenous individuals and how this history ties into the trauma of today. Most of the individuals in the workshop this morning are police and security. Many of these individuals live in that new smart city, so it’s good for them to hear what the true history of this country is and the genocide that was enacted by the government that still is in power today. When Christopher Columbus got lost, and we as indigenous people found him, life changed for ever for us. Pre Columbus, indigenous people had an amazing simple life, living by the instructions given by the creator to live in harmony with all of our relatives including those that grow on earth, walk on four legs, fly, crawl and swim. How people survived the cultural genocide with our languages and traditions still intact speaks to our resilience. How important it is for those who live in that smart city to understand how to interact and work with indigenous people and this should include all cultures and helping to understand newcomers as well. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/ea9d6ba0-d64a-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Slide presentation about history of peace disruption",
+                        "description": "Slide presentation about history of peace disruption",
+                        "fileDetails": {
+                            "lastModified": 1568314169425,
+                            "name": "Timeline.jpg",
+                            "size": 2294488,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "At Work - Afternoon",
+                        "blockType": "text",
+                        "text": "After I have done that for the morning, I had my lunch and I’m going to go to the afternoon where I work with the individuals. My work with individuals is around self-determination and how to survive in today’s world, helping them to understand the social norms and orientation to the rules. Many of the people I work with are women fleeing the violence by their significant partner or family members of the missing and murdered indigenous women. For my clients’ survival it is absolutely important to know about social norms and surviving in today’s world of the dominant culture i.e. relationship to white privilege. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Self-Care",
+                        "blockType": "text",
+                        "text": "What a busy day I have had! and now I have to go to the park and rejuvenate myself. I have brought my medicine that I am going to burn and my hand drum to recreate the heartbeat of mother earth. So, I can connect with my ancestors and not take home the emotions of fear after a hard day of work. You don’t have to take home the other people’s trauma. Today is one of those good days when no one in the park complains to me about my behavior. Some days people in the neighborhood ask me to leave the park because they say that it is loud, and they can’t stand the smell of my medicine burning and, on some days, they literally attack my (physically)—White privilege. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eaa0c700-d64a-11e9-878e-13cc3403c489.jpg",
+                        "alternativeText": "Hand drumming in the park",
+                        "description": "Hand drumming in the park",
+                        "fileDetails": {
+                            "lastModified": 1568314682129,
+                            "name": "Drum.jpg",
+                            "size": 89106,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eaa11520-d64a-11e9-878e-13cc3403c489.JPG",
+                        "alternativeText": "Smudging in the park",
+                        "description": "Smudging in the park",
+                        "fileDetails": {
+                            "lastModified": 1568316698275,
+                            "name": "smudging.JPG",
+                            "size": 247792,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "mediaUrl": "./uploads/eaa18a50-d64a-11e9-878e-13cc3403c489.mp4",
+                        "alternativeText": null,
+                        "description": "Video showing my path home. The sky is getting cloudy and dark and it seems that it's about to start raining. ",
+                        "blockType": "video",
+                        "fileDetails": {
+                            "lastModified": 1568317212430,
+                            "name": "Video.mp4",
+                            "size": 10388798,
+                            "type": "video/mp4"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "End of My Day",
+                        "blockType": "text",
+                        "text": "Now it’s time to go home and wouldn’t you know it starts to rain. I hated it when it rains when I go home because I leave south of Gardiner and it’s well known that during a rainstorm it floods under the Gardiner, creating headaches for those one of us trying to get home. Because of Toronto’s lack of infrastructure, the swear floods and the water seeps up to the street and in some case creates power outages and increase pollution in water. When the swear overflows seeps up to the sidewalks and overflows over the manholes and flooding the union station and cars are stuck there. I’m worried about my dog drinking this water and being affected by it. I’m also worried about power outage and if I can get to my unit. \n\nLuckily, I get home and the power is on. So, I take the elevator to my condo and take Jubo for a walk. \n"
+                    }
+                ],
+                "title": "Getting Around",
+                "author": "KWEUK (Women Collective)",
+                "tags": []
+            }
+        },
+        "ee8d2ca0-d4fb-11e9-b489-e9b807f15c0e":
+        {
+            "type": "story",
+            "value": {
+                "id": "ee8d2ca0-d4fb-11e9-b489-e9b807f15c0e",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Grachel takes the train",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/ee895c10-d4fb-11e9-b489-e9b807f15c0e.jpeg",
+                        "alternativeText": "Grachel decides to take the train into Toronto to try and find a new restaurant. She's coming from the suburbs and isn't familiar with the TTC.",
+                        "description": "Grachel decides to take the train into Toronto to try and find a new restaurant. She's coming from the suburbs and isn't familiar with the TTC.",
+                        "fileDetails": {
+                            "lastModified": 1568250242219,
+                            "lastModifiedDate": "2019-09-12T01:04:02.219Z",
+                            "name": "Train2.jpeg",
+                            "size": 10524,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "A new world...",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/ee89d140-d4fb-11e9-b489-e9b807f15c0e.jpg",
+                        "alternativeText": null,
+                        "description": "As Grachel gets settled on the train, an anxiety overtakes her. She realizes she doesn't have the card necessary for payment, and she panics when she reviews the system map - and begins to try to navigate. She feels overwhelmed and a little scared!",
+                        "fileDetails": {
+                            "lastModified": 1568250747271,
+                            "lastModifiedDate": "2019-09-12T01:12:27.271Z",
+                            "name": "TTC.jpg",
+                            "size": 63613,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "The train's other passengers...",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/ee8a1f60-d4fb-11e9-b489-e9b807f15c0e.jpg",
+                        "alternativeText": "As she tries to manage her confusion, she gets a whiff of an old and musty smell. She looks around but sees nothing, until she peaks over the edge of the row of seats right in front of her. She finds a man sleeping. Right as her eyes settle on his resting body though, he stirs to wake - with wild eyes and a shudder. He jumped up and yelled - saliva going everywhere and the stench of unbrushed teeth billowing out like a mushroom cloud. Grachel popped up and ran as fast as she could to another car to finish her journey.",
+                        "description": "As she tries to manage her confusion, she gets a whiff of an old and musty smell. She looks around but sees nothing, until she peaks over the edge of the row of seats right in front of her. She finds a man sleeping. Right as her eyes settle on his resting body though, he stirs to wake - with wild eyes and a shudder. He jumped up and yelled - saliva going everywhere and the stench of unbrushed teeth billowing out like a mushroom cloud. Grachel popped up and ran as fast as she could to another car to finish her journey.",
+                        "fileDetails": {
+                            "lastModified": 1568250403369,
+                            "lastModifiedDate": "2019-09-12T01:06:43.369Z",
+                            "name": "TTC-sleeping.jpg",
+                            "size": 36686,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Food, finally.",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/ee8a4670-d4fb-11e9-b489-e9b807f15c0e.jpeg",
+                        "alternativeText": "After finally arriving into the city and getting off at the first stop that seemed safe, and withdrawing cash from an ATM in order to pay for a new transit card, Grachel exited the station and found a nearby food court. She wanted to try something new and different, and the food court featured a Nigerian restaurant that looked promising. But excitement quickly turned to frustration and a feeling of being overwhelmed - as the expansive menu was full of unfamiliar terms and pictures. After a few too many minutes of standing and staring blankly at list of various dishes, she turned and walked away - dejectedly heading for Tim Horton's and the safety of a turkey sandwich.",
+                        "description": "After finally arriving into the city and getting off at the first stop that seemed safe, and withdrawing cash from an ATM in order to pay for a new transit card, Grachel exited the station and found a nearby food court. She wanted to try something new and different, and the food court featured a Nigerian restaurant that looked promising. But excitement quickly turned to frustration and a feeling of being overwhelmed - as the expansive menu was full of unfamiliar terms and pictures. After a few too many minutes of standing and staring blankly at list of various dishes, she turned and walked away - dejectedly heading for Tim Horton's and the safety of a turkey sandwich.",
+                        "fileDetails": {
+                            "lastModified": 1568251370430,
+                            "lastModifiedDate": "2019-09-12T01:22:50.430Z",
+                            "name": "nigerian food.jpeg",
+                            "size": 164787,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "title": "Grachel Goes to Town",
+                "author": "Grachel + Joe",
+                "tags": []
+            }
+        },
+        "fa182c50-d640-11e9-9605-5d78aa190f9a":
+        {
+            "type": "story",
+            "value": {
+                "id": "fa182c50-d640-11e9-9605-5d78aa190f9a",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Since the beginning of our time, my ancestors walked this land. I have always felt great comfort knowing that where my footsteps, my ancestors have also stepped in the same place, long ago. At one time we had full access to our land, water, and all that resided in and on it. We had access to all of our medicines, to our language, to our culture and ceremonies. We could stand on the water’s edge and drink directly from the shores, we had all that we needed to survive and thrive in our communities following the seasons, the sun the moon and the stars. We travelled freely along the lands surrounded by its comforts and bounty and were a greater part of that community, helping anyone in need and being part of that village. \n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/fa119ca0-d640-11e9-9605-5d78aa190f9a.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568317669045,
+                            "lastModifiedDate": "2019-09-12T19:47:49.045Z",
+                            "name": "inukshuk.jpg",
+                            "size": 74764,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Since the colonization of man, the connection to the earth has suffered. Where I was once able to put my feet in the water, I now have to stand on a pier looking over. Huge condo developments deny my access to it and it has become a commodity that has been privatized and commercialized. All the plant medicines have been replaced and colonized as well by plants and seeds from other lands. Concrete laying over these plants, the seeds have since gone to sleep. Where we were able to view the travels of the sun, the moon and the constellations, the buildings have grown taller and taller, fighting for real estate space in the sky, blockin out our access to it. Large trees have been replaced by much smaller ones and our access to green space has been denied. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/fa11c3b0-d640-11e9-9605-5d78aa190f9a.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568223364000,
+                            "lastModifiedDate": "2019-09-11T17:36:04.000Z",
+                            "name": "IMG_0012.jpg",
+                            "size": 1787292,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/fa145bc0-d640-11e9-9605-5d78aa190f9a.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568223906000,
+                            "lastModifiedDate": "2019-09-11T17:45:06.000Z",
+                            "name": "IMG_0018.jpg",
+                            "size": 337400,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Losing access to our land and to the rhythm of the seasons has removed all empathy and compassion from us, as a whole, so that what we have done to the land, we are now doing to the people. We have become focused on development and economic growth at the detriment of the fringed society where we are made to feel invisible and unheard. When I walked through my neighbourhood, old storefronts that were once family owned, are now replaced with larger brand named stores that could afford the high rental rates. Cultural centers, Free Clinics and public access buildings were being relocated and replaced by starbucks, Tim Hortons, Urban Outfitters and other corporate entities, removed all the individuality that made up our neighbourhood affecting single mothers, refugees, All homeless, those with addictions and mental health affected communities. Access to Shelters, food banks, walk in clinics being replaced by private practices in a tiered healthcare system, shelters are moved to the suburbs, further denying basic human needs to the people that make up my community so that they have no choice but to move away. The green spaces that I enjoyed with my children growing up, became parking lots and then became condo developments, which only the rich can afford, making me feel like a stranger in my own neighborhood. \n\nAll that I have witnessed in my community is a direct result of colonization. The taking over of lands replacing inaccessible resources to those who cannot afford and gentrifying spaces making them inaccessible causes those that are affected by these changes to suffer as a result. As a single mother with three children, I cannot afford to move out of our one bedroom apartment and with all the development makes affordable housing a pipe dream. \n\nElder Jay Mason told me once, that there is nothing civilized about civilization and long after he is gone, I can see this for my own eyes. In the presence of urban development I see fragmentation of humanity, further marginalizing the most vulnerable and weak. Much like cement is paved over nature, I see the same happening to people. \n\nAs I walk the streets I see directly how the homeless are affected, how police presence is more prominent. How a homeless man is bullied because he had alcohol open in a park, gets a 300 dollar ticket and a six month ban from the park (his home) while they look the other way at all the public drinking that is available and even encouraged at street festivals and beer gardens, throughout the city. Buildings and public spaces are designed to make it impossible for those that are homeless to find a place to sleep, or segmented benches making laying down impossible. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/fa14f800-d640-11e9-9605-5d78aa190f9a.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568319477738,
+                            "lastModifiedDate": "2019-09-12T20:17:57.738Z",
+                            "name": "images.jpg",
+                            "size": 11042,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Police involvement is based on personal biases and even Indigenous police have been assimilated to the point where they are enforcing colonial laws against their own people for simply being visible. This makes me concerned, not only for our community that once was, but for the future of my children, that they will be scrutinized by the families and the children they grew up with are now afraid of them because of their socio-economic status. \n\nPolice involvement is based on personal biases and even Indigenous police have been assimilated to the point where they are enforcing colonial laws against their own people for simply being visible. This makes me concerned, not only for our community that once was, but for the future of my children, that they will be scrutinized by the families and the children they grew up with are now afraid of them because of their socio-economic status. \n\nIn one of my travels I came across a dandelion growing in the crack of the sidewalk and it reminded me of the resiliency of mother nature. How resilient our plant medicines are that even though we have long paved over them, the seeds have been asleep and are now waking up. It reminded me of the resiliency of humans and how we strive for that connection, and although we may only be a plant creeping up from a crack, underneath that sidewalk, our roots are connected to each other. Where the government has failed to help the people, I have seen the roots in the community grow and reach out to help eachother. \n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/fa151f10-d640-11e9-9605-5d78aa190f9a.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1568319876651,
+                            "lastModifiedDate": "2019-09-12T20:24:36.651Z",
+                            "name": "plant.jpg",
+                            "size": 167696,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Where again those without monetary gain are usually the most charitable toothers in their community. Where government programs have failed, grassroots programs have thrived. People leading their own patrols, policing their own communities. Opening their doors, feeding the people and being that village. I have seen the outpour of kindness and generosity from those who have nothing because it is in their nature to give because they know what it feels to live without. \n\nThinking back to the uncivilized nature of civilization makes me wonder how can we improve the urban environment to include all. I am reminded of my traditional background and how I look towards how we survived without the amenities that now give us comfort. How when we think of smart city, my idea of smart doesn’t involve Electronic apps, or billboards with information, surveillance cameras everywhere and constant light and sound pollution. That all of these mess with our circadian rhythm, turning us into insomniacs and further harms those like my sons with autism, who have sensitivities to lights and sounds causing stress, overthinking and mental health issues due to constant information overload. \n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "A smart city for me would focus on sustainable living practices for all that improve our everyday living and the communities we live in. \n\nIncorporating more green spaces that are not only accessible to all, but also are affordable to all. Using rammed earth, strawbale, adobe, cobb, in our structures to reduce our strain on the environment. Making Internal walls out of recycled products like pop cans, plastic water and glass bottles so that they don’t end up in landfills. I think about how this type of housing would benefit all of my friends on the street and make affordable housing more accessable. How this type of thinking can benefit the design of a smart city which would create accessible homes for low income as well as for those that can afford market rate. A tiered building system so that each apartment can growtheir own food with passive solar windows and out door patios that encourage the owners to grow their own foods. Not only is affordable housing important, but it is also essential to change our ways of thinking so that different economic brackets can live side by side without stigma and judgement. That a smart city would embrace all public access. I dream that our public transportation would be tied into our tax system so that it would be free for all, or that it would be geared to income. So that it would be more equitable for people like me don’t have to pick between putting money on a presto card or feeding my children that week, just so that I can go to work to support my family. The idea of an equitable society is a true smart city, where it is accessible to your needs and not based on your socio-economic status. I see a community being supported like all aspects of the medicine wheel. That it would support the mental, emotional, physical, spiritual aspects that holistically support our well being. \n\nAll of those aspects of the human conditioning can be healed through greenspace. \nRemoving contained gardens and making them accessible to the people so that all Schools and buildings have greenhouses, where children can learn how to grow their own food and lunch and breakfast programs in the school can benefit from it. As well as nuturing the childs connection to nature. All green spaces contained lush gardens that can provide nourishment as well as stimulation to the senses. I see a community of food gardens, Healing gardens, fruit trees, edible flowers making food accessible to all. This is the way to moving towards a smart city, and to bring the idea of civilized, back to civilization. \n"
+                    }
+                ],
+                "title": "smart city, bringing back civilized to civilization. ",
+                "author": "Cathy Walker",
+                "tags": [
+                    "Gentrification. Greenspace."
+                ]
+            }
+        }
+    }
+});

--- a/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/cities_stories_0.3.0_to_0.4.0_migration.js
+++ b/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/cities_stories_0.3.0_to_0.4.0_migration.js
@@ -1,0 +1,68 @@
+/*
+For copyright information, see the AUTHORS.md file in the docs directory of this distribution and at
+https://github.com/fluid-project/sjrk-story-telling/blob/main/docs/AUTHORS.md
+
+Licensed under the New BSD license. You may not use this file except in compliance with this licence.
+You may obtain a copy of the BSD License at
+https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.txt
+*/
+
+// These eslint directives prevent the linter from complaining about the use of
+// globals or arguments that will be prevent in CouchDB design doc functions
+// such as views or validate_doc_update
+
+/* global sjrk, emit, newDoc, oldDoc, userCtx, secObj */
+/*eslint no-unused-vars: ["error", { "vars": "local", "argsIgnorePattern": "newDoc|oldDoc|userCtx|secObj" }]*/
+
+"use strict";
+
+require("infusion");
+fluid.setLogging(true);
+var sjrk = fluid.registerNamespace("sjrk");
+
+require("../../singleNodeConfiguration");
+require("./cities_stories_0.3.0_to_0.4.0_documents");
+
+
+// Mix-in grade for all the couch configuration
+// components when actually used to configure
+// the DB
+fluid.defaults("sjrk.storyTelling.server.dbSetup.core", {
+    distributeOptions: [
+        {
+            target: "{that}.options.couchOptions.couchUrl",
+            record: "@expand:kettle.resolvers.env(COUCHDB_URL)"
+        },
+        {
+            target: "{that}.options.components.retryingBehaviour.options.retryOptions.maxRetries",
+            record: "@expand:kettle.resolvers.env(COUCHDB_CONFIG_MAX_RETRIES)"
+        },
+        {
+            target: "{that}.options.components.retryingBehaviour.options.retryOptions.retryDelay",
+            record: "@expand:kettle.resolvers.env(COUCHDB_CONFIG_RETRY_DELAY)"
+        }
+    ],
+    listeners: {
+        "onCreate.configureCouch": "{that}.configureCouch"
+    }
+});
+
+// sets up a new instance of the core setup along with replicatorDb defined
+sjrk.storyTelling.server.replicatorDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with usersDb defined
+sjrk.storyTelling.server.usersDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with globalChangesDb defined
+sjrk.storyTelling.server.globalChangesDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with the storiesDb defined
+sjrk.storyTelling.server.storiesDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});

--- a/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/floe_stories_0.3.0_to_0.4.0_documents.js
+++ b/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/floe_stories_0.3.0_to_0.4.0_documents.js
@@ -1,0 +1,1874 @@
+/*
+For copyright information, see the AUTHORS.md file in the docs directory of this distribution and at
+https://github.com/fluid-project/sjrk-story-telling/blob/main/docs/AUTHORS.md
+
+Licensed under the New BSD license. You may not use this file except in compliance with this licence.
+You may obtain a copy of the BSD License at
+https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.txt
+*/
+
+// These eslint directives prevent the linter from complaining about the use of
+// globals or arguments that will be prevent in CouchDB design doc functions
+// such as views or validate_doc_update
+
+"use strict";
+
+require("infusion");
+require("kettle");
+
+require("fluid-couch-config");
+
+// sets up the Storytelling Tool database migration using fluid-couch-config
+fluid.defaults("sjrk.storyTelling.server.storiesDb", {
+    gradeNames: ["fluid.couchConfig.pipeline.retrying"],
+    couchOptions: {
+        dbName: "stories"
+    },
+    listeners: {
+        "onSuccess.logSuccess": "fluid.log(SUCCESS)",
+        "onError.logError": "fluid.log({arguments}.0.message)"
+    },
+    dbDocuments: {
+        "0e967c80-3aac-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "0e967c80-3aac-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "I learned to act and memorize my scripts",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "What I learned from my teachers and classmates",
+                        "blockType": "text",
+                        "text": "In drama class my teacher teach us how to act and memorize our script . Well with the help of my classmates on my group I can enhance my acting skills, about emotions. My teacher gave a project about the influential drama teachers. Learning their styles not to do if your in the stage doing nothing just waiting for your time to come, that influential person help us not to use the same mistake as we did the time we perform in front of students and the people that watched the show."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "I am the Main Character",
+                        "blockType": "text",
+                        "text": "And the day comes and everything I learned I've use it. I tried hard to avoid having the important part. in the show where I perform in teachers and students are not so nerve wreaking but this one just my classmates and teacher but so much stress. I am the main character and i need to memorize so many line I need to memorize it at home, free time, lunch and well the period I need to memorize it. I need to ask my friend for the emotions I need to put in that scene. And the most hardest thing is being the bad girl there and at first I cant finish my lines and my classmate says i'm such a good girl. i will tell you the feeling is so new to me that's why. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "D'day",
+                        "blockType": "text",
+                        "text": "I will tell now is the day i'm doing it. the feeling of nervousness, the chill into my spine, the feeling of scared. memorizing my script all night long even day. looking like crazy memorizing a lines with emotion thank me that i'm with my friends less stress. I didn't look at the other performer because i'm memorizing my script. And the nervousness go in the flow the the first scene because i should be nervous in that scene. It came well and as the other putting myself in that place as the person who is doing the blind date. And the feeling that all of my blind dates are all crazy feeling tired of the craziness. And it ends well and all the chill, too much nervousness has gone and I can say no more im done."
+                    }
+                ],
+                "author": "No. 4",
+                "tags": [
+                    "drama",
+                    "memorizing script",
+                    "acting"
+                ]
+            }
+        },
+        "151e03c0-879b-11e9-b178-a79380bdbe47": {
+            "type": "story",
+            "value": {
+                "id": "151e03c0-879b-11e9-b178-a79380bdbe47",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "My experiences camping",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "When I was 7 years old I went camping for the first time. It was spring, I was in a tent, and I was with my friends in a cub scout troop. Since then, I’ve loved camping. I go relatively often with my scout troop, and I have had many insane experiences. I have changed my style slightly since then. About 2 years ago, my friend and I tried a challenge we called the “no tent challenge.” It was camping, outside, but without a tent. We hung a rope between two trees and put a tarp over that tent style. Now, I almost never camp with a tent. I have made tons of different shelters, with different people, in different weather. I have slept in shelters with -45o C temperatures, with tornado winds blowing my shelter over 6 times throughout the night, and with foxes circling it (that was a really scary experience). During the tornado winds, I barely slept whatsoever, but the next night we fixed up out shelter, and I then slept extremely well. Now I always look forward to camping trips, and enjoy building new shelter ideas. \n"
+                    }
+                ],
+                "author": "",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "177fcea0-264d-11e9-a55a-317414fdb830": {
+            "type": "story",
+            "value": {
+                "id": "177fcea0-264d-11e9-a55a-317414fdb830",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Breaking our assumptions",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "When I immigrated to Canada, I expected facing many challenges, but I never thought that technology would be one of them. Technology was part of every different task in this new country unlike what I was used to in my home country. Among all those experiences, there is one incident that haunted me for years and still makes me feel frustrated when using a piece of technology in front of a crowd. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "After a year of moving to Canada around 2005, I started going back to school to qualify my degree. In one of my first classes, we were assigned to present to the class about a particular topic. I used our family computer at home to prepare my presentation, burnet it on a CD and brought it to the class. With a quick look around me, I realized that no one is using a CD. Then, I noticed that everyone was using the teacher’s laptop to present. It was a LAPTOP and not a HOME COMPUTER! had never used a laptop before… feeling frustrated, I wondered where I should insert my CD. I quickly scanned the class to see if anyone was using a laptop and find out what I should do with my CD. I felt dumb, really really dumb… "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Finally, it was my turn to present. I walked to the front, anxiously sweating and frustrated. When I reached that laptop, I noticed it was different from my classmate's laptop that I had just decoded–it was a MacBook! There was no indication of a CD rom. I was stressed, I was looking at it but couldn’t process my thoughts. Those few seconds felt like years of embarrassment. I finally asked the teacher to help me insert the CD. During my presentation, I was only thinking about how to get that CD out of that machine. I couldn't see the eject button… at the end I had to ask for help again. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/17787ba0-264d-11e9-a55a-317414fdb830.JPG",
+                        "alternativeText": null,
+                        "description": "An image of a MacBook Pro's CD slot and eject Button - This is a newer model than what was used in my class. ",
+                        "fileDetails": {
+                            "lastModified": 1549043825000,
+                            "name": "MacBook Image.JPG",
+                            "size": 1977371,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Although the whole experience took less than 20 minutes, it had a lasting impact on me. After many years of experiencing similar challenges, I finally decided to deal with it. I realized that these incidents are not just my fault, they happen because of all the assumptions we make every day. In that class, the teacher had assumed everyone was comfortable using a MacBook. Now, I surrender right from the beginning to break those assumptions. I try to express what I need and ask for help. It is difficult and sometimes very stressful, but it immediately removes the pressure off of me and let me better focus on what needs to be done. "
+                    }
+                ],
+                "author": "anonymous",
+                "tags": [
+                    "technology",
+                    "challenges",
+                    "presentation",
+                    "fear"
+                ]
+            }
+        },
+        "18fb2950-3aac-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "18fb2950-3aac-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Being Independent",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Learning to be independent. I have learned to be independent on my school works and accepting any challenges or situations that involves my priorities. Giving enough time on my studies and my happiness. But sometimes asking someone's help if needed. Doing my responsibilities as much as possible. Like choosing books more often. When going home maybe begin to study.To make it easier to be independent is to be confident on what you do in life. Be more attentive in my works and learning to love on what I am doing. But sometimes we need exercise our body so I'm taking gym this semester for 45 min. of exercise and like 135 mins. of mental class.\n\n#Life Goals"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "\nPag-aaral na maging malaya. Natutunan ko na maging malaya sa aking mga gawa sa paaralan at pagtanggap ng anumang mga hamon o sitwasyon na nagsasangkot sa aking mga priyoridad. Nagbibigay ng sapat na oras sa aking pag-aaral at kaligayahan ko. Ngunit kung minsan ay humihingi ng tulong ng isang tao kung kinakailangan. Paggawa ng aking mga responsibilidad hangga't maaari. Tulad ng pagpili ng mga aklat nang mas madalas. Kapag pumunta sa bahay ay maaaring magsimula sa pag-aaral. Upang gawing mas madali ang maging malaya ay upang maging tiwala sa kung ano ang iyong ginagawa sa buhay. Maging mas matulungin sa aking mga gawa at pag-aralang mahalin ang ginagawa ko. Ngunit kung minsan kailangan naming mag-ehersisyo ang aming katawan kaya kinukuha ko gym ang semestre na ito para sa 45 min. ng ehersisyo at tulad ng 135 min. ng mental na klase.\n\n#Life Goals"
+                    }
+                ],
+                "author": "Myth",
+                "tags": [
+                    "Responsibilities"
+                ]
+            }
+        },
+        "1a202150-3aac-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "1a202150-3aac-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "How did I become confident",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "",
+                        "blockType": "text",
+                        "text": "This is my story on how i become confident. Learning how to be confident is hard because, the people who is not used to being with people like me can get a hard time just by looking at the eyes of the people that I meet .The first time that I tried to get out of my shell, I feel so uncomfortable, It felt like i was on a big stage naked.\nAfter my first try I already gave up on trying again but then my mother know that there is something wrong about me, so my mother consult me and told me that i'm handsome and that really boost my confidence.In my second try, this time I tried another approach,I used the internet and watch videos about how to be confident and after hours of searching I found a channel that helped me,this channel really help me the most because, on how the owner of the channel is so confident and really know what he's talking about, the thing that i remember the most that this guy says is \"BE YOURSELF\",this words really struck me, when i stuck these words in my head it really felt good because, It made me realize that being confident is not following steps, its just being you.This means don't be like a guy/girl who doesn't have a real personality,your not like some people who just follow everyone's expectation because everyone is unique in their own way.Then when I become confident,sometimes I still feel awkward but now I say that its not like when I first started.This is my story on how i become confident.\n"
+                    }
+                ],
+                "author": "Mr. Confident",
+                "tags": [
+                    "confident",
+                    "how to relieve stress",
+                    "be assure of yourself"
+                ]
+            }
+        },
+        "1d7623d0-28c9-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "1d7623d0-28c9-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "From Fear to Letting Go",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "From Fear to Letting Go",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/1d6f1ef0-28c9-11e9-98f6-71413982cc35.jpeg",
+                        "alternativeText": null,
+                        "description": "My travels take me to many places that become part of who I am and what I aspire for in the future. Different connections with people who open up their lives and homes to me and all contribute to my sense of identity. Sometimes I reach a point of transformation and it requires a great sense of trust in the flow of life.",
+                        "fileDetails": {
+                            "lastModified": 1549317528970,
+                            "lastModifiedDate": "2019-02-04T21:58:48.970Z",
+                            "name": "73eae2b0-24b3-11e9-865f-b5fe084cdb92.jpeg",
+                            "size": 2136739,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "author": "Jennifer",
+                "tags": [
+                    "Flow"
+                ]
+            }
+        },
+        "22d85230-2a3b-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "22d85230-2a3b-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "My travelling",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "LEARNING EVERYTHING FOR THE FiRST TIME: My first time in airplane, I didn’t know how to wear a seatbelt and where it is.\nI looked near and behind me. I was afraid. Then my son showed me how to use it.\nAfter that I learned a new thing because another day if I get on the airplane \nI can do it myself And help someone who doesn’t know how use it.\nI feel happy and more confident. I want to learn more skills."
+                    }
+                ],
+                "author": "",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "236186b0-40f5-11e9-a3fc-117f000e6d4c": {
+            "type": "story",
+            "value": {
+                "id": "236186b0-40f5-11e9-a3fc-117f000e6d4c",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "About the lock ",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "when I came to Canada, I went to school. They gave us a lock. I did'n know how to use it . It was hard for me to use it because we did not use it in our country. I told my teacher I need help. She came and explained to me but I didn't understand english. There was one girl who spoke Arabic and she translated for me and it got better. "
+                    }
+                ],
+                "author": "MZ",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "2777d9f0-3aad-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "2777d9f0-3aad-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Moving in a new country ",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "What I learned here in Canada",
+                        "blockType": "text",
+                        "text": " Moving here in Canada was a very hard part for me because I need to get used to most of the things here. It was very difficult for me to get used to a new environment. I have to learn how to speak English confidently to the people around me. I have to get used to be able to communicate with people to have friends and other reasons such as ordering food and etc . At first, it was pretty hard but as days go by, and with practice I realized that I only need more confidence in talking with other people even though I make mistakes I can learn from it and improve my skills. I also learned how to be more responsible because back at home we were depending on other people while here I have to make my own decisions. I learned how to manage my time wisely like waking up to school and etc . Another experience that was fun for me was learning how to ride train and buses, back at my hometown there was no trains we only use jeeps and taxis for transportation. It was fun for me to learn where to ride and stop on a place to go where I want to go. I also experienced to present on a stage because last semester I took music and it was difficult at first for me but overtime I got used to it and saw the performance as a challenge and it was a fun experience for me because I learned how to play guitar and read music notes, it was a very memorable experience for me."
+                    }
+                ],
+                "author": "Anonymous 16",
+                "tags": [
+                    "Riding a bus",
+                    "Learning a new language",
+                    "Riding a bus",
+                    "New to a country"
+                ]
+            }
+        },
+        "2931a1f0-879b-11e9-b178-a79380bdbe47": {
+            "type": "story",
+            "value": {
+                "id": "2931a1f0-879b-11e9-b178-a79380bdbe47",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "The first day",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I was laying in my bed, not quite ready to get up yet. Not wanting to get up. It was September 4th, 7:00 am and the first day of grade 6 was starting in 2 hours. But I wasn’t in my sender school. I was in the gifted program at a new school. I thought about how much I missed my friends at my old school and how nervous I was. Would the gifted program be a million times harder? Would we have homework every single day?? Would I know anyone??? I was already dreading school, and it hasn’t even started yet.\n\nWhen I arrived at the new school, I realized it wouldn’t be much different from my old school. I met lots of people in my class who were also new and I felt a bit more at ease. There weren’t many differences, and I wasn’t nervous anymore. To this day, I’m still in the gifted program and I’m happy with my class."
+                    }
+                ],
+                "author": "Gelato",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "2ad53090-3abf-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "2ad53090-3abf-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "my view of canada",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "This is am first time come to canada, I like this country because there have great education, health care, transportation system. And, most of the people are kind, I remember when I first time use the TTC, I lost and most of the TTC officer will listen to me patiently and tell me where should I go. This is a great experience that tell me how canadian is. \nAlso, I was a ESL student, but after make friend, read many news report and watch english news in youtube. My english have a great impact, I can read news article easier than before and I think some of the left gone way too far in some of their policy. But, anyway that is just my opinion. I think if I keep doing that I can improve my knowledge, and that is a good thing for me. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": null
+                    }
+                ],
+                "author": "abc",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "2ca452c0-2a8e-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "2ca452c0-2a8e-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "My favorite things.",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "My favorite things.",
+                        "blockType": "text",
+                        "text": "I would like to write about my story. This is a picture of my Cake. I baked it. I really interested of baking. When I bake something my feel be very enjoyable. Usually I bake cakes and cookies, any desserts. When I baking while I listen to music and singing song. It’s to be really wonderful time for me.\n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/2ca0a940-2a8e-11e9-98f6-71413982cc35.jpeg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1549510372000,
+                            "name": "8FE228DF-9FD8-4FAD-9454-C5FCFCDD849F.jpeg",
+                            "size": 290355,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/2ca1e1c0-2a8e-11e9-98f6-71413982cc35.jpeg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1549510840000,
+                            "name": "57C5E49E-C0B6-4532-BB2E-26973F679F04.jpeg",
+                            "size": 257124,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "author": "Mubina",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "2d8bbdf0-5caa-11ea-a24f-b72ef3f26124": {
+            "type": "story",
+            "value": {
+                "id": "2d8bbdf0-5caa-11ea-a24f-b72ef3f26124",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "authoringEnabled": true,
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I have a computer supplied by the school board. It has been broken since last year so I sometimes can’t do my work. My mom has been trying to get me to take notes in history class so the other day I pulled out my phone and opened google keep. My mom showed me the app so I tried it. It was working pretty good and I was taking notes. My history teacher came around and pointed to my paper on the desk and said that the pen and paper were for note taking, not my phone and I had to put my phone away. He doesn’t understand. \n"
+                    }
+                ],
+                "title": "Taking notes",
+                "author": "",
+                "tags": []
+            }
+        },
+        "2dbb8f80-879e-11e9-b178-a79380bdbe47": {
+            "type": "story",
+            "value": {
+                "id": "2dbb8f80-879e-11e9-b178-a79380bdbe47",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Global warming",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "\nGlobal warming is when the carbon dioxide (otherwise known as CO2) is damaging the ozone layer. The ozone layer protects us from the sun’s rays, so since the ozone layer is damaged, the sun’s rays are making the earth hotter. This is causing icebergs to melt and water level to rise, causing floods. \n\nGlobal warming makes me mad now because a lot of people know about global warming, believe in global warming, say they will do something to help, and they still don’t do anything. Also, you shouldn’t use air conditioning. You should really use a fan or water, because air conditioning, although intended to make you cool, actually is one of the things that contributes a lot to the global warming problem. I think people should think of the long term effects over the short term effects!\n\nGlobal warming is happening faster then ever. Some places are in danger of flooding. Also, a lot of animals are dying, including polar bears and seals! If global warming keeps going, at this rate, the earth is going to be inhabitable in around a single generation. \nFor the people who say global warming doesn’t exist, there is a lot of proof. Giant icebergs have been melting. Also, the global temperature has increased by at least 1 °C. That may not seem like a lot, but I think that the amount of carbon dioxide (a chemical that damages the ozone layer (ozone layer protects us from the sun’s rays)) is increasing in amount and therefore the earth is getting hotter and the icebergs are melting. \n \nAlso, because of global warming, there have been a lot more natural disasters. I have experienced a flood because of that. Tornados and a lot of other natural disasters also increase in number now!!!!!!!!!!!!!!\n\nEveryone has a part they need to do to stop global warming. For example, people need to take a bike instead of a car, and even if they can’t they should take public transit because there are a lot of people there already. You can also stop using heaters as often and actually just wear a sweater instead and during bedtime just wear multiple layers of sheets. \nEven if you can’t do a lot, you can still spread the information in try to encourage other people to help out. The future is not looking so great, and it won’t be great unless we make a difference. But together we can save the earth! \n\nP.S. One person can make a difference!!!! \n"
+                    }
+                ],
+                "author": "Enviralment",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "2fbf9d20-2a39-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "2fbf9d20-2a39-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "How My wife and I decided to move to Canada",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I would like to tell a story that how My wife and I decided to move to Canada.\n After I graduated from university in China,I found a relatively good job and got married with My wife.After three years hard work,We bought an apartment in My hometown and got a higher position in My company,everything seemed good that time.\n However,things were changing! In October,2016,My wife and I traveled to Europe in our honeymoon.It was during that time that We found The world outside was colorful, and there were different people and different culture there. We realized that there was a lot of things We should experience,instead of the repeated everyday life in My homecity."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/2fbd7a40-2a39-11e9-98f6-71413982cc35.jpeg",
+                        "alternativeText": null,
+                        "description": "Our trip to Europe",
+                        "fileDetails": {
+                            "lastModified": 1549454423000,
+                            "name": "33BA769E-814A-4384-B7C1-64EFBA3C88A5.jpeg",
+                            "size": 107135,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "After struggling for a long time, We finally made a decision that We would give up everything in my hometown and move to a new country-Canada.\n We knew that It was difficult to restart a life,but It is worthy experiencing a brand new life,which We thought was exciting!\n After arriving in Canada in August,2018, It took a long time for us to settle down. Language problems,low credit,financial problems and new social systems all troubled us seriously.However,We do not fear anything,because We believe that time will help us get better and better!"
+                    }
+                ],
+                "author": "ZD",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "30af2fb0-3ac0-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "30af2fb0-3ac0-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "My experience about learning language",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "This is my story about learning a skill. Language is difficult for me. When I first came to this country. I was uncomfortable in here entirely. Language was a big problem for me. I didn't understand what people said and didn't know how to communicate with others. English was as the second language in China, we just learnt some grammar in the school and didn't speak English in normal life. After a period of time, I went to the school to study. It was strange and felt very nervous. Fortunately, I met some people, they knew I was new here, they were greeting with me passionately and would like to help me. I made with friends with them. When I had problems in language, they were very kind to help me. I learnt some about the language when they explanation with me. During that time, I didn't understand the courses entirely but I had to learn. In this environment, I had to learn the language. Language was most important and necessary to master. In the school, I improved my English skills slowly because friends' help and the environment factor. "
+                    }
+                ],
+                "author": "Ynnah",
+                "tags": [
+                    "learn the Language skills"
+                ]
+            }
+        },
+        "35b5a520-40f6-11e9-a3fc-117f000e6d4c": {
+            "type": "story",
+            "value": {
+                "id": "35b5a520-40f6-11e9-a3fc-117f000e6d4c",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "My first day in Canada school ",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "When I came to Canada, I did not know how to speak english, the only think I knew it was to say hello and how are you? and I remember, in my first school in my first day, my mom was said when somebody said what is your name, you answer my name is Mariana and you? and then I went to in school , when I went to school everything was different from my country school or in Brazil in that school had lockers the room was different and I saw a lot of things and I was a little nervous but people came to me and said hi to me and then I went to the officer and they showed me somebody who spoke the same language like me and this made me happy and I was thinking nobody spoke the same language like me and this made me so happy and I went to the class and same thing did not it was all most everybody was from others country. so they can understand how was to learn others language and I now make new friends and I have lot of fun in that school."
+                    }
+                ],
+                "author": "M",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "3c9f3210-3aad-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "3c9f3210-3aad-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "How to ice skate",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I came here in Canada on 2016 and after 1 week i went to school and they are speaking English and i wasn't talking to anyone. After 1 month i can speak a little bit English and and started to make friends. My cousin invited me to ice skating and that was my first time to ice skate and i thought it was easy to ice skate because it looks easy and when i stepped on the ice with my skate shoes i slipped and my cousin helped me how to skate. And after 1 year I Learned and became good at it and break dancing on the ice. I learned how to skate because ice skating is fun, enjoying and make friends. Ice skating is not easy to learn if your afraid and if your not afraid to fall you gonna learn fast. Ice skating is nice when your free styling on the ice and you can break dance as well. "
+                    }
+                ],
+                "author": "Kian",
+                "tags": [
+                    "ice skate"
+                ]
+            }
+        },
+        "3d2afa40-2a39-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "3d2afa40-2a39-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "My story is about moving from Jordan to Canada \nIn Jordan I had money problems. \nAll people from Syria can't to go work in Jordan.\nWhen l come to Canada l said l want to go back to Jordan.\nTwo months later I didn't want to go back to Jordan anymore!\nAn now l am happy because now I can speak English and I have good friends. \n"
+                    }
+                ],
+                "author": "",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "44165be0-3aad-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "44165be0-3aad-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "How I learned on how to use the bus",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I learned how to use the bus and the train . At first it was hard for me because I didn't always use the bus when I was a kid so I didn't know how to use or ride the train. When I heard that I need to use the bus in order to go to school , I was so nervous because I have never ridden a bus or train ever in my life unsupervised . But good thing I had friends teaching me how to use the bus or the train. At first , learning on how to use the bus was very hard and scary for me because I thought I'm gonna get lost not knowing how to go home. Luckily my friends thought me how to use the bus. Now I know how to ride the bus and the train so now I can go to many places whenever I want."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "My first experience on using the bus myself is when the school had a late start schedule. My friend went to Philippines in order to bond with her family so I was alone at that time . I was so nervous because this is was my first time using the bus by myself. But luckily, I had one other friend who also taught me on how to use the bus but we never use the same bus together , and so I asked him. He gave me directions on how to use the bus in order to go to school . It was 9:30 AM at that time due to the late start. Thanks to him I was able to go to school at the right time ."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "For my recommendation to those who are scared of trying new things, you should have the courage to try new things in order to accomplish it because its not that hard if you really try it . Because the first time I used the bus was hard but if you get used to it it will turn out to be easy and actually not hard. And yes sometimes it can be challenging depending on the situations but you have to fight in order to accomplish it."
+                    }
+                ],
+                "author": "",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "57490f70-879a-11e9-b178-a79380bdbe47": {
+            "type": "story",
+            "value": {
+                "id": "57490f70-879a-11e9-b178-a79380bdbe47",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Brothers",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Brothers are interesting. It’s like they have two sides, they are either nice and helpful, or they are moody and mischievous. And I have two of them, so you can imagine what life is like. Sometimes they can make me really, really mad, but at least I have someone to play with, and someone who is there for me. Both of my brothers are younger than me, and one of them is a baby, wherever he goes there is disaster. The pros of having a brother- they are comforting, you have someone to play with, they can be amusing, they stand up for you (sometimes), and the cons of having a brother- they can be really annoying, they can be abnormally mischievous, they can be really mean, and they can be tattletales. I want to have a good relationship with my brothers when I am younger so when I am older I will have a good relationship with them then too. Before my second brother was born I was hoping he was going to be a girl. But when I found out that he was a boy I was kind of disappointed, but now I am happy that he is my brother and not my sister (FYI- I don’t have a sister). My 8 year old brother always blames me for things, but in the end I am happy that he is my brother and I don’t care that he blames me for every little thing. There was one time where I really freaked my brother out. Like, I scared his socks off. But I didn’t think it would really do anything. What I did is I hid under his covers on his bed and I waited for him to enter his room, when he did I popped up from the covers and said ‘boo!’ But the lights were off and he thought that I was in my room. So he screamed and started crying, my parents ran to his room and automatically knew that I had scared him. I was really in trouble. But I felt really, really, really bad about it, and now that I look back on it I regret it so, so much. I just thought that he would take it as a joke, but he didn’t. I think that brothers are awesome and if you have one, you are very lucky. I hope that my brothers are always there for me, because I will always be there for them."
+                    }
+                ],
+                "author": "Anonymous",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "6028a360-3aad-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "6028a360-3aad-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Learning to drive a car",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I learned to drive a car. I chose to this to tell because It was memorable and I can't forget those memories with my dad. My dad and I was on a car. He's teaching me to drive a car. On that time I realized that driving a is not easy. When my sister is driving I always get bored because her speed is 40 kph all the time. I always tease her because I don't like when the driver is driving slow and steady. At first time, I wasn't expected that driving is way too hard than driving a bicycle. I thought driving a car is easy but suddenly when my turn or when my dad declared that I'm next to my sister, I get nervous. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Driving a car for me is very difficult because my feet on that time can't reach the fuel guage. I remember on that time my dad was giving up on me because I had a hard time learning. Were almost get crash and my dad was nervous too. I wasn't really expected that driving a car is not easy. We took 2 to 5 hours a day just to teach me, and I really appreciated those effort of my dad. My dad really don't gave up on me but he motivated me that I can overcome my driving lesson. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "After 3 months, I can now drive a car without my dad. Because of him I now can drive independently. The most difficult I've experienced is driving, but now I'm now good at driving and I can now drive at highways"
+                    }
+                ],
+                "author": "Jan Carlo Torres",
+                "tags": [
+                    "hardworks"
+                ]
+            }
+        },
+        "63801940-2a3a-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "63801940-2a3a-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "About myself ",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "They’re three things important to me on my life."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/63787820-2a3a-11e9-98f6-71413982cc35.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1549474773000,
+                            "name": "image.jpg",
+                            "size": 632644,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "The coins mean many things to me it from my country. It’s one thing I have from Syria.i will save that forever I can’t forget anything from Syria."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/63787820-2a3a-11e9-98f6-71413982cc35.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1549475326000,
+                            "name": "image.jpg",
+                            "size": 1825049,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "The mosque for Muslim people is more than a place of worship. We use the mosque for study , business and activities. We use it for a community centre. The mosque welcomes all people who respect the places."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I will save all those things forever. I learned a lot of things from my life and more skills to work with people. I hope to not lose anything from my life."
+                    }
+                ],
+                "author": "",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "702789c0-473c-11e9-a3fc-117f000e6d4c": {
+            "type": "story",
+            "value": {
+                "id": "702789c0-473c-11e9-a3fc-117f000e6d4c",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Deaf Education",
+                        "blockType": "text",
+                        "text": "Hi, I thought I would tell my story as a hearing person on how I learned ASL and Deaf Culture.\n\nI started volunteering with the deaf at St. Francis Deaf Community and Holy Name Church in 1970. I remember that I would attend the Mass on Sunday morning and then join in for Tea and Coffee after. I knew the alphabet from being a young girl and having one deaf girl who lived on my street that I would go and visit and play with. At that time the alphabet was all we used and oral communication. When I sat with the Deaf having Tea and Coffee they were a little hesitant to speak or teach me signs as I was a young girl of 16. the more I kept coming to Mass for the Deaf and Social events slowly they accepted me and communicated with me. \n\n At the same time I was a volunteer with the children in teaching Religion. That had to be done Orally as per the government regulations. During this time a met a young deaf women who loved music and wanted to learn the words etc to songs she had heard / felt the music for. I became friends with her and after classes on Saturday afternoons with the children, would go to her place and write the words to the songs and then try to sign them or learn the signs. This was very helpful to my learning ASL as it made my signing a little smoother.\n\nIn the early 1970 's there was no formal Sign Language Courses so you learned from individuals and being involved. As time went on I became very fluent in signs and when there was any course I could attends to develop my education, I tried to attend. \nLearning ASL is a continuous journey and I thank the Deaf for this . I meet many Deaf from all over Canada and the USA which has helped me so much. \n\nI now consider the Deaf as part of my Family and THANK them for allowing me to be part of their world."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": null,
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": null
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "mediaUrl": null,
+                        "alternativeText": null,
+                        "description": null,
+                        "blockType": "audio",
+                        "fileDetails": null
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "mediaUrl": null,
+                        "alternativeText": null,
+                        "description": null,
+                        "blockType": "video",
+                        "fileDetails": null
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": null
+                    }
+                ],
+                "author": "Carol Stokes",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "71080660-40f4-11e9-a3fc-117f000e6d4c": {
+            "type": "story",
+            "value": {
+                "id": "71080660-40f4-11e9-a3fc-117f000e6d4c",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "My story is about cooking ",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I know how to cook. my Mom teach me how to cook. I am cooking for my self. and also I like cooking. one time I cooked pasta that was very spicy . and no body eat yet. I told them please eat it. and they are said we will eat this. but this is very spicy. and then i was so sad for that. and when I am cooking i fell so good and nice. because I like cooking. and become i need to learn more about cooking . like I need to cook pizza soup rice and kabab. "
+                    }
+                ],
+                "author": "S k",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "73e65960-3aad-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "73e65960-3aad-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "How to ice skate",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I came here in Canada on 2016 and after 1 week i went to school and they are speaking English and i wasn't talking to anyone. After 1 month i can speak a little bit English and and started to make friends. My cousin invited me to ice skating and that was my first time to ice skate and i thought it was easy to ice skate because it looks easy and when i stepped on the ice with my skate shoes i slipped and my cousin helped me how to skate. And after 1 year I Learned and became good at it and break dancing on the ice. I learned how to skate because ice skating is fun, enjoying and make friends. Ice skating is not easy to learn if your afraid and if your not afraid to fall you gonna learn fast. Ice skating is nice when your free styling on the ice and you can break dance as well. "
+                    }
+                ],
+                "author": "Silent k soul",
+                "tags": [
+                    "ice skate"
+                ]
+            }
+        },
+        "757d01a0-879e-11e9-b178-a79380bdbe47": {
+            "type": "story",
+            "value": {
+                "id": "757d01a0-879e-11e9-b178-a79380bdbe47",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "The Happiest Day of my Life",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "The happiest day of my life",
+                        "blockType": "text",
+                        "text": "One day in March 2017 it was a weekend when me and my mom where really bored so I asked her if she wanted to get a pet. She said yes right away and that was one of the happiest moments of my life. we went straight to the pet store, when we got there the petsmart assistant said the most ideal pet for our house would be a Guinea pig, the next day me my mom and my brother did some research about what they eat and what they like to do. It was about 5 days later when my mom said we were ready to get a pet. Me and my family drove back to the store only to find out that you needed to get two guinea pigs, because they are social animals which means they need a partner. I was feeling sad because we might not get them if there are two but if we did get them I would be even happier. A few moments later my mom agreed to getting pets so I yelled yay because that was the happiest day of my life. To this day I am still happy every time I get home because I am greeted by my two guinea pigs named Luna and Scruffy."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/75786dc0-879e-11e9-b178-a79380bdbe47.jpeg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1559744930418,
+                            "lastModifiedDate": "2019-06-05T14:28:50.418Z",
+                            "name": "03CDDA19-5E44-4DC5-A3B8-18FD3FD8236A.jpeg",
+                            "size": 1817378,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "author": "FaZe_Tfue",
+                "tags": [
+                    "My new pet"
+                ]
+            }
+        },
+        "93a03290-2a3a-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "93a03290-2a3a-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Memories of my childhood ",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I would like to write about my story. This is a picture of me with my nephew when I was a little baby. \nI have only two pictures from my childhood they are valuable to me because they are all the pictures I have. The first picture was in Iraq I was living with my family before the war it was a safe, free country and everything was easy. The second picture was taken before my family and I visited Turkey. \nIn Canada my new life is great, I think working with people and respecting each other is great. Also Canada taught me a lot of things. I’m really very grateful to Canada. I hope that days of my childhood will return."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": " This is picture of me when I was in my home country ",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/93978000-2a3a-11e9-98f6-71413982cc35.jpeg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1549476104000,
+                            "name": "CB8EA97A-95B5-49BC-8DF8-16D9357EDD58.jpeg",
+                            "size": 3133323,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "This is a picture with my nephew ",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/939e5dd0-2a3a-11e9-98f6-71413982cc35.jpeg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1549476208000,
+                            "name": "459D658F-458B-43BC-BE7D-A388F264A130.jpeg",
+                            "size": 554767,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "author": "Ghazwan ",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "a1290a10-40f4-11e9-a3fc-117f000e6d4c": {
+            "type": "story",
+            "value": {
+                "id": "a1290a10-40f4-11e9-a3fc-117f000e6d4c",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "learning how to use computer",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "The first time I saw a computer I didn't know everything about it. The teacher helped me to use the computer. I practiced and after 2 years I learned how to use the computer at school. \n\n\n "
+                    }
+                ],
+                "author": "king",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "a177e2a0-879b-11e9-b178-a79380bdbe47": {
+            "type": "story",
+            "value": {
+                "id": "a177e2a0-879b-11e9-b178-a79380bdbe47",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "The fire!",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "When I was in grade 4, I really needed to go to washroom so I went. When I entered I discovered a fire! Apparently the hand dryer had exploded! I was so scared because I didn't want to be engulfed in flames and burn. I felt like I couldn't move but then I shook my head and immediately ran out of the washroom. I told the nearest teacher. The teacher went inside and quickly put out the fire. In the end I was happy that I did the right thing and tell a teacher."
+                    }
+                ],
+                "author": "",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "a3a87710-40f6-11e9-a3fc-117f000e6d4c": {
+            "type": "story",
+            "value": {
+                "id": "a3a87710-40f6-11e9-a3fc-117f000e6d4c",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "little girl",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "mediaUrl": "./uploads/a3a65430-40f6-11e9-a3fc-117f000e6d4c.m4a",
+                        "alternativeText": null,
+                        "description": null,
+                        "blockType": "audio",
+                        "fileDetails": {
+                            "lastModified": 1551974666000,
+                            "lastModifiedDate": "2019-03-07T16:04:26.000Z",
+                            "name": "New Recording 5.m4a",
+                            "size": 404197,
+                            "type": "audio/x-m4a"
+                        }
+                    }
+                ],
+                "author": "m c",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "a51dec50-28c9-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "a51dec50-28c9-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "LOVE IS LOVE 7",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "LOVE IS LOVE 7",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/a51c3ea0-28c9-11e9-98f6-71413982cc35.JPG",
+                        "alternativeText": "Friendship, true love!",
+                        "description": "This picture represents the friendship that I have with my friends and my two sisters. On this day in 2011, we went from Quebec city to Montreal city to do a fundraising in Montreal subways stations for the children of Gaza, the Rohingya community and the Syrian refugees. All those smiles and energy represent our personalities and the love that we share with everyone!",
+                        "fileDetails": {
+                            "lastModified": 1549317656205,
+                            "lastModifiedDate": "2019-02-04T22:00:56.205Z",
+                            "name": "45c6f210-24b4-11e9-865f-b5fe084cdb92.JPG",
+                            "size": 460277,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "author": "",
+                "tags": [
+                    "friendship",
+                    "love",
+                    "sharing"
+                ]
+            }
+        },
+        "a62af8c0-2a38-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "a62af8c0-2a38-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "My hopes ",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "My goals,hopes,problems etc.",
+                        "blockType": "text",
+                        "text": "My story begins when I was younger 18 years old. Years ago when I was younger, I did not have problems about life and future. I am getting grown up and my problems grow up with me. \n\nWhen I was 19 years old, I came to Canada. I have to choose my way and I chose. I will learn English and go to school. \n\nI had chosen my way but there are always ways in the life. Never it will finish. \n\nNow,I am 20 years old. I want a good life and job. I need hard work for these goals and of course luck. \n\nI should be hopeful for my future. I don’t know for now, what can I do for these goals but I have thoughts and hope for the future. "
+                    }
+                ],
+                "author": "",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "a973a5f0-40f3-11e9-a3fc-117f000e6d4c": {
+            "type": "story",
+            "value": {
+                "id": "a973a5f0-40f3-11e9-a3fc-117f000e6d4c",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "learning how to cook",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "My first day of cooking was at my house. I was so nervous in the kitchen. I thought I was gonna make a fire, a big fire. But after two days I learned because my uncle and my mom helped me how to cook and the next day my family tried to eat my food and they said the food was very good. I was proud of myself."
+                    }
+                ],
+                "author": "EC",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "ac70af10-3aad-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "ac70af10-3aad-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "the day I learned how to speak another language ",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "For almost five years I've been living in Canada and it feels like an adventure . I've been to many places and learned so much things beyond my expectation. but in those years it wasn't all good ,there was also a challenge that came with it and this is how my story begins . When I first came to this country the only thing on my mind was getting good grades till the day a teacher came to my classroom and started to speak in another language . At first I was curios , what kind of language is the teacher speaking. Someone told me that we were learning another language .I was freaked out and felt like i was done for not because i got a D in my first day learning another language it is because i never thought i would learn another language . Because of this i lost focus on my work and i felt like giving up . I told my mom about this and she answered \"what ever is putting you down and felt like giving up don't hesitate to stand back up \" . Ever since that day i had courage and reason to stand back up for me to learn and understand this concept . A year has past i finally am able to catch up and continue what i started. this is my story:)"
+                    }
+                ],
+                "author": "Ridge Angelo Facun",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "acf01b20-40f6-11e9-a3fc-117f000e6d4c": {
+            "type": "story",
+            "value": {
+                "id": "acf01b20-40f6-11e9-a3fc-117f000e6d4c",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "اول يوم بل باص",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "اول يوم اجيت علئ كندا كنت ما اعرف استعمل الباص ورحت مرا علمدرسة وضعت وبعدين تعلمت كيف استعمل الباص وهلق صرات اعرف كيف استعمل الباص واروح وين ما بدي وانبصطت كتير وهلق اتمنه اني اتعلم الطرقات عشان روح وين ما بدي واتمنه الكل يتعلم لانو ازاما يعرفو ما راح يقدرو يعملو الي بدهم ايه "
+                    }
+                ],
+                "author": "YE",
+                "tags": [
+                    "باص"
+                ]
+            }
+        },
+        "b1374550-2a3a-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "b1374550-2a3a-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I am from Ethiophia . In 2014 I laft to Kenya Kakuma camp. I was working in a business for 5 years. After those years, I left to Canada so i like canada. I can change my life now. "
+                    }
+                ],
+                "author": "",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "b2b3e510-40f5-11e9-a3fc-117f000e6d4c": {
+            "type": "story",
+            "value": {
+                "id": "b2b3e510-40f5-11e9-a3fc-117f000e6d4c",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "My story is about cleaning house",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I know how to clean house. When my mom she went to the mall for shopping and I was at home a lone and I clean my house and my room kitchen. I wash dishes. when my mom she came to home. she was so happy for that. because I cleaned house.and she kiss me. and she very happy.and I was so tired."
+                    }
+                ],
+                "author": "k k",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "bdd42440-40f6-11e9-a3fc-117f000e6d4c": {
+            "type": "story",
+            "value": {
+                "id": "bdd42440-40f6-11e9-a3fc-117f000e6d4c",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "مدرسة",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "نا تعلمت احكي انجليزي لانو ماكنت اعرف من قبل بس كانت صعبا كتير لانو ماكنت احكي ولا اقراء بس كانت كتير صعبا علي بس انا تعلمت بكندا كتير اشياء اول شي تعلمت احكي انجليزي وتاني شي ماكنت اعرف عل كنبيوتر بعدين تعلمت على وصرات اعرف استعمل الكنبيوتر وكمان انا ماكنت اعرف استعمال الباص بعدين صرات اروح عل مدرسه بل باص وبعدين صرت اعرف استعمل الباص"
+                    }
+                ],
+                "author": "MA",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "c35ae7b0-3abf-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "c35ae7b0-3abf-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Learned how to play video games",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "",
+                        "blockType": "text",
+                        "text": "In my whole life, I have learned so many things. For me I think learned how to play games is the most easy. My first time playing video game was when I was 12. before that my life was all about school. which it makes me so boring , so I decided to learned new things, which was video games. when I first played it, I found it more fun than studying. For one reason was because it has so many different types of games. The games also separate the level differently. It had easy, intermediate and hard mode, but later on I was so in love with it, my school marks had been dropped because of that. My parent started to forced me managed the time. After it, I tried to play less, but later on I was out of it, cause I can't find the passion when I first played it. so I learned how to play video games, also known how can managed the time and control time. It was a big lesson for me. I still play video games right now. "
+                    }
+                ],
+                "author": "zed",
+                "tags": [
+                    "learning games/ managed time"
+                ]
+            }
+        },
+        "c75baf70-3abf-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "c75baf70-3abf-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "My second language",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "The first time I learned English is in China. English is a very hard language. I was learning about some basic English then I came to Canada. At first I was so scared and nervous ,because it's the first time I go to other country. The first day I went to school in Canada. I was so nervous,because I don't know how to communicate with other people. When I go to the class i felt nervous and scared. I don't know what other people saying. I can't communicate with other people,that the effect me to learn English. I knew some friends in school, they help me a lot. When I don't know something or some words is hard for me they always help me to understand. Now, I start to understand what they are saying and try to communicate with them."
+                    }
+                ],
+                "author": "Yasuo",
+                "tags": [
+                    "learn English"
+                ]
+            }
+        },
+        "c8c4c740-3abd-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "c8c4c740-3abd-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Bad friends around you - suggestions",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "",
+                        "blockType": "text",
+                        "text": "Avoiding bad friends around you is a skill that you have to have in your daily life."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Why do you need to avoid bad friends around you? Cause there are some bad thinkings and bad habits, and some of them can't figure out or don't want to listen to others' suggestions about them. If you stay with them day by day, you will kind of following their habits, their bad speakings, and at that time it is too late for you to change your habits, you would be used to it."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "There are some people showing themselves, speaking loudly at the public places, saying something bad, that will give you the first feelings about them, remember them and try not to have an intersection with them. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "There are also some people act great at first, but some small habits or actions in daily life will destroy the good feelings that you have built for them. Then just keep away from them."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "But, the things up top is based on you don't have a strong character on leading your friends. If you don't want to change your mind and you do have the skills that can change your friends from bad to good, then do it. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Life is a strange thing and full of regrets, but do not regret staying away from your bad friends. If you have something concerned about with your friends or worried about if your friends are good or not, first you must have correct views based on your life. And focussing on your friends, maybe you can notice something that you won't find in your daily life. That maybe will change the feelings about your friends.\n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "There are also some problems caused by bad friends, such as loving couples, strange thinkings, bad mood. That is why you need to have this important skill in your life. There is an old saying in China, \"if you stay beside the ink, you will become black one day\", it basically means that your friends can influence you. So think about the friends beside you and make the decisions now. "
+                    }
+                ],
+                "author": "SHFL",
+                "tags": [
+                    "Bad friends",
+                    "suggestions"
+                ]
+            }
+        },
+        "d1a35900-3aac-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "d1a35900-3aac-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Learning how to build Confidence ",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Hi I'm just want to tell my experience that its hard to me to order food from restaurant or fast food. Its hard for me to order because I'm just came here in Canada for just few months and I was still learning the language here. I used to speak 'tagalog' back in our country. And another reason that I can't order because I have lack of confidence, I thought that every one making fun of me every time I order my food. One thing that learned through months is be friendly and make friends, Because when i was on my first day at school I thought there is no one Flipino but then there is a lot of it. I'm luck because I think 40% of the student in the school Filipino. And that how my confidence build up, Because one of my friends in school taught me to be how to get over my problems. And that's it to get over your problems make alot of friends to build up confidence and how to be independent. Don't forget that there is always a friend to help you."
+                    }
+                ],
+                "author": "Boltubs",
+                "tags": [
+                    "Making friends",
+                    "Building up Confidencce"
+                ]
+            }
+        },
+        "d476c450-24b3-11e9-865f-b5fe084cdb92": {
+            "type": "story",
+            "value": {
+                "id": "d476c450-24b3-11e9-865f-b5fe084cdb92",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "My Life as a River",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "My Life as a River by Dallas"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/d47034a0-24b3-11e9-865f-b5fe084cdb92.JPG",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1548868940000,
+                            "lastModifiedDate": "2019-01-30T17:22:20.000Z",
+                            "name": "IMG_1988.JPG",
+                            "size": 1926836,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "author": "Dallas",
+                "tags": [
+                    "Life River"
+                ]
+            }
+        },
+        "d8627900-2a3b-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "d8627900-2a3b-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Moving to Canada",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "This is my story of when I moved to Canada. Moving to Canada was a little bit hard Because I stay home for two months. After that I found a job and then I went to work just for six months .And then I started language school.When I Was in my country if I feel sad my family helped me specialy my niece. I remember when I felt sad if I play with her I forget anything . Because I Love her very much and I really miss her .But in Canada it is a little bit hard .Anyway now It is going great .Everything is easier than seven month ago. And I hope it will be easier in the future and I want to learn more to improve my language skills.Finally my opinion :life can be hard but you work harder you are on your way."
+                    }
+                ],
+                "author": "SB",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "d8d011b0-3abf-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "d8d011b0-3abf-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Future Destination",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "A Programmer's Life",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/d8ce3cf0-3abf-11e9-98be-695d9e3c45a1.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1551292765223,
+                            "lastModifiedDate": "2019-02-27T18:39:25.223Z",
+                            "name": "30643267165_8411c85bd5_b.jpg",
+                            "size": 245960,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "2017, the most special and important year for me, which I finally found my own future destination after 16 years wandering in the world. It happened when I was choosing my grade 12 courses for next school year. I spent more than 4 months to solve it , even though most people think it's not too hard to design their future. During those 4 months, I muddled through each day, didn't know what to or what's the meaning of my life. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "The turning point would be my parents heard my story and flied to Canada to help me out. I finally decided that i'm going to learn about computer science, and try to become a programmer after me and my parents had an argument. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Few months later, I looked back to figure out why did I feel it's hard and why I could not make my own decision. Suddenly, I realized that the main reason would be I was not sure what's my hobby or what I really like to do. Also, I was afraid of making bad decision that will destroy my whole life. I asked my parents one more time, they said:\"Don't be afraid at all. In the future, if you find that you don't like what are you doing, you can choose another pathway, as long as you want. There is no right or wrong about future, only you like or not. Beside, you are a only 16 years old boy who has lots of time to waste or make wrong decision.\" My dad told me about his story. He said he doesn't like to work in the bank when he was 27, so he jumped out and spent 2 years to learn statistics which was what he liked. Later on, he was hired by another company, and he enjoys what he is doing now."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "After all, I understand that the worst thing is staying at current achievement and never moving forward, instead if you make decision that you don't like, at least you can learn from it. "
+                    }
+                ],
+                "author": "Bubble Fish",
+                "tags": [
+                    "Choice",
+                    "Future"
+                ]
+            }
+        },
+        "dc9cd940-2a39-11e9-98f6-71413982cc35": {
+            "type": "story",
+            "value": {
+                "id": "dc9cd940-2a39-11e9-98f6-71413982cc35",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "My life story",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I came from Somalia.\nI was born in Somalia and I left to Ethiopia when I was 8 years old.\nWhen I arrived in Ethiopia , I strarted studying. I learned a lot from different subjects Like: Somali, Amharic, English, physics, biology, chimes trey, maths, E.T.C.\nI was learning in Ethiopia over and over for 8 years- I lived half of my life there.\nI was there for a while and ( for more tan 8 years ), I came to Canada. \nEthiopia and Canada have a bigger gap. Such as development , life, and like."
+                    }
+                ],
+                "author": "",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "dccd4550-5ca9-11ea-b5cc-0f7c24539387": {
+            "type": "story",
+            "value": {
+                "id": "dccd4550-5ca9-11ea-b5cc-0f7c24539387",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "authoringEnabled": true,
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I’m in grade 8 and go to school from Monday to Friday. I take a bus to my specialized program and that takes about an hour each way. I have 6 classes each day and sometimes have to move to a different classroom. I use a computer to write with but this year I have been trying to write with a pencil or pen and paper because my computer keeps breaking. Sometimes I HAVE to write with pencil and paper because that’s all the teacher supplies for a test or worksheet or because it’s a lot of extra work to look at a printed exercise sheet then put answers on a blank google doc and go back and forth. It gets confusing sometimes and I get distracted. "
+                    },
+                    {
+                        "authoringEnabled": true,
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I don’t like having to change from one class to another because I don’t get time to focus on a topic or project. The topics and projects have lots of steps and I need time to figure it out and do things properly."
+                    },
+                    {
+                        "authoringEnabled": true,
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "The other day I stayed home from school and worked in my mom’s studio with her. She has a big table with a bench that I sat at for the morning. I worked on a project that was due in a couple of days. What I liked about working at home, besides being with my cat and dog, was that I could take as much time as I needed to do the project, ask my mom questions and get answers right away, stand up and walk around, talk about things that interested me related to the project (but not part of the project), and have help understanding the instructions for the project.\n"
+                    },
+                    {
+                        "authoringEnabled": true,
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I presented my project the other day in class and think I did ok, but was sad that I forgot to talk about a few things. \n"
+                    },
+                    {
+                        "authoringEnabled": true,
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I might be able to do school work from home at least one day a week, my mom is talking to the school about it. I was trying to figure out if I can do school work better in the morning or afternoon to help decide if I should do half days at home or one full day. My mom suggested that maybe the mornings are better because I’m usually the first one up (sometimes even at 3am!). But I’m thinking about all the other things in my day that I have to do: cleaning the cat litter, walk the dog, my homework, chores—stuff like that. And the things I want to do: video games, reading, video games, badminton, video games, mindfulness martial arts, video games (hahaha). \n"
+                    },
+                    {
+                        "authoringEnabled": true,
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I don’t want to give up my friends in school, the ones whom I’ve known since I started going to another school outside my community in grade 4. They know me and I know them and we play games during the lunch break. \n"
+                    }
+                ],
+                "title": "Getting my work done",
+                "author": "",
+                "tags": []
+            }
+        },
+        "dea165c0-25ad-11e9-a55a-317414fdb830": {
+            "type": "story",
+            "value": {
+                "id": "dea165c0-25ad-11e9-a55a-317414fdb830",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "The choice",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Don't let school interfere with your education",
+                        "mediaUrl": "./uploads/de990150-25ad-11e9-a55a-317414fdb830.aac",
+                        "alternativeText": null,
+                        "description": "A short story of a choice I made to focus on real world change instead of writing silly papers.",
+                        "blockType": "audio",
+                        "fileDetails": {
+                            "lastModified": 1548975328000,
+                            "lastModifiedDate": "2019-01-31T22:55:28.000Z",
+                            "name": "Voice0060.aac",
+                            "size": 3491719,
+                            "type": "audio/aac"
+                        }
+                    }
+                ],
+                "author": "Liam O'Doherty",
+                "tags": [
+                    "Education",
+                    "employment",
+                    "decision making"
+                ]
+            }
+        },
+        "dfe98870-879d-11e9-b178-a79380bdbe47": {
+            "type": "story",
+            "value": {
+                "id": "dfe98870-879d-11e9-b178-a79380bdbe47",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "The Crash",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "One day, I was biking with my family to the C.N. tower.\nIt was a nice bike ride, until the incident on the way back. I was biking around a corner when a car came zooming around.\nI was hit.\nI was so scared, and I thought that was the end, but luckily, they braked in time, and all I got from it was a scar.\nEven so, I am forever traumatized, and I will not bike to the C.N. tower ever again.\nThis event changed me as a biker, not because of the Tower itself, but because of the fact that I was taking the route to the C.N. tower when I got hit (I will still walk to it though).\n\nThe end"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "CN Tower",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/dfe73e80-879d-11e9-b178-a79380bdbe47.jpg",
+                        "alternativeText": "Picture of the C.N. Tower, which is a skinny tower with a point at the top.",
+                        "description": "One of the tallest structures in the world.",
+                        "fileDetails": {
+                            "lastModified": 1559740618901,
+                            "lastModifiedDate": "2019-06-05T13:16:58.901Z",
+                            "name": "cn-tower-toronto-ontario-th.jpg",
+                            "size": 198547,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "author": "NDS",
+                "tags": [
+                    "C.N. Tower",
+                    "Crash"
+                ]
+            }
+        },
+        "e5ca8010-87d8-11e9-b178-a79380bdbe47": {
+            "type": "story",
+            "value": {
+                "id": "e5ca8010-87d8-11e9-b178-a79380bdbe47",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Learning to spell took 25 years",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "When I was in school (elementary and high school) I was learning two languages, English and French. I lived in an area that was 98% French and we spoke English at home. I could more easily understand the spelling of French words than I could English words. English words didn’t visually make sense to me, I associated the sound of words with shapes but English had so many “exceptions”. Because I wasn’t doing well on my spelling tests and I always had the least number of stickers on the evaluation board that everyone saw every day I felt like I wasn’t smart. This stayed with me for a very long time until I learned to spell and write when I started a job and got to work with stories, writers and copy editors. This was the best (and most fun) learning I had. I even became an editor after several years of learning on the job. It’s also important to know that I never told anyone about my learning difference or how I felt because of it—I think I would have been less lonely if I could have talked about it!\n"
+                    }
+                ],
+                "author": "CC",
+                "tags": [
+                    "spelling",
+                    "language"
+                ]
+            }
+        },
+        "ea0261e0-3abf-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "ea0261e0-3abf-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "A hunter",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Hello, everyone. Today, I would type some of my life story. I have came here for 2 years. When I was in grade 9, I took career class. From this class, I learned how to write a resume and cover letter. It really help me to find a job in the future. In high school, I also learned about writing skills in my English class. My teacher taught me how to write an essay. An essay can help me get higher mark in English test. The last skills I learned is from video games. I used to play video games by my father's computer. Till last month I bought a ps4 pro. I like trying new games. This steps really make me exciting. From video games, I could learn a lot. Like new game Apex Legends.I can learn teamwork, attack enemies together, share the material with my teammate. I really learn a lot from game. Through those things, I think I can learn more skills in the future."
+                    }
+                ],
+                "author": "Jack",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "f0496030-3aab-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "f0496030-3aab-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Learning something requires process ",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Presenting something in front of a class is not easy as I thought it was going to be because you're going to be exposed in front and speaking to many people. Way back home in the Philippines I wasn't that kind of person who likes to present in front or even recite something on class even it's my language because I grew up with a family where my family members does not have connection with each other. So I grew up with no confidence in myself and become so shy person."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": " But when I came here in Canada my life really changed, I thought it's gonna be easy for me to communicate using an English language but it wasn't. Since I'm a shy type person I couldn't talk to someone using English. When school starts again, I wasn't that ready but I have to! At first, I thought I have to introduce myself in front but thank God because I didn't do that. It's kinda nervous and it's also kinda embarrassing to be in front with your classmates and teachers who's listening to you. You may missed pronounce words and your classmates will laugh at you is gonna be the most embarrassing moment in your life. Personally, I am a shy type person who doesn't want to be exposed to many people. I don't even want to talk to someone or approaching/asking them how was their day? or how's their school?"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "But since, each day of my life I learned how to be confident to speak to other people without any hesitation or nervous, I also learned how to present in front with confidence. And I learned those because my teachers really pushed me to do that, they were the one who believed in my skills and they were also the one who told me that I can do it. They said that I have to believe in myself and to conquer my fears and now, I already have the confidence to present in front without any fear or any hesitations. And because of my teachers out there who really taught me to be very confident, Thank You! Because of you all, I stepped out my self to my comfort zones. And to those students out there who has fear and hesitating to present in front, You all can do it!! Just always practice, believe in yourself, and have confident to show your ability to others. I hope, I inspire some of you! :) "
+                    }
+                ],
+                "author": "",
+                "tags": [
+                    "Public speaking",
+                    "Having confidence"
+                ]
+            }
+        },
+        "f233f280-3af5-11e9-98be-695d9e3c45a1": {
+            "type": "story",
+            "value": {
+                "id": "f233f280-3af5-11e9-98be-695d9e3c45a1",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "It's cold outside",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Hello, I emigrated to Canada 10 years ago. \nI'm still not used to the snow...\n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": null,
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": null
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "mediaUrl": null,
+                        "alternativeText": null,
+                        "description": null,
+                        "blockType": "audio",
+                        "fileDetails": null
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "mediaUrl": null,
+                        "alternativeText": null,
+                        "description": null,
+                        "blockType": "video",
+                        "fileDetails": null
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "mediaUrl": null,
+                        "alternativeText": null,
+                        "description": null,
+                        "blockType": "audio",
+                        "fileDetails": null
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": null,
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": null
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": null
+                    }
+                ],
+                "author": "Henrique",
+                "tags": [
+                    ""
+                ]
+            }
+        },
+        "f506e680-5ca9-11ea-b5cc-0f7c24539387": {
+            "type": "story",
+            "value": {
+                "id": "f506e680-5ca9-11ea-b5cc-0f7c24539387",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "authoringEnabled": true,
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "We get a lot of printed worksheets and handouts in math class. I find them confusing because they are always different to me. They look different and what they are about is different. We have to do all the worksheets and then the teacher tells us the answers in class and we mark our own stuff. After each module--say geometry--we have hand in all our worksheets to the teacher. They count for marks. When I went to hand in mine the teacher wouldn’t accept them, she told me to organize them. I went back to my desk and did that but she still wouldn’t accept them. I didn’t tell anyone but my mom found out when she was organizing my binder with me. She asked me if there were any instructions on how to organize everything, like a rubric with some “scaffolds” on how to do it. Well there isn’t. I was really angry when I told her the story.\n"
+                    }
+                ],
+                "title": "Organizing my math papers",
+                "author": "",
+                "tags": []
+            }
+        },
+        "f8e405f0-24b3-11e9-865f-b5fe084cdb92": {
+            "type": "story",
+            "value": {
+                "id": "f8e405f0-24b3-11e9-865f-b5fe084cdb92",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Learning to live with Anxiety & Depression",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Living with Anxiety and Depression",
+                        "blockType": "text",
+                        "text": "My learning journey involves learning to live with depression/anxiety. It started by identifying the things that would ground me and help lift me out of those periods of my life. The three things that help with that are my music corner, records/cds, and my pets. When I started this journey, it was hard to identify when these periods of anxiety and depression were coming up. Eventually I learned what the beginning of anxiety looked like for myself, and what the beginning stages of a depressive episode looked like as well. It took a long time to identify these triggers that would put me on a path to anxiety and depression. As I learned more about myself and my relationship with both anxiety and depression, I found ways that I could ground myself and prevent myself from spiralling into those episodes. The things that I found worked were going back to playing music, listening to my records, and hanging out with my pets. These same three things are what I had forgotten about when I first experienced the biggest episode of anxiety and depression. "
+                    }
+                ],
+                "author": "M",
+                "tags": [
+                    ""
+                ]
+            }
+        }
+    }
+});

--- a/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/floe_stories_0.3.0_to_0.4.0_migration.js
+++ b/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/floe_stories_0.3.0_to_0.4.0_migration.js
@@ -1,0 +1,68 @@
+/*
+For copyright information, see the AUTHORS.md file in the docs directory of this distribution and at
+https://github.com/fluid-project/sjrk-story-telling/blob/main/docs/AUTHORS.md
+
+Licensed under the New BSD license. You may not use this file except in compliance with this licence.
+You may obtain a copy of the BSD License at
+https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.txt
+*/
+
+// These eslint directives prevent the linter from complaining about the use of
+// globals or arguments that will be prevent in CouchDB design doc functions
+// such as views or validate_doc_update
+
+/* global sjrk, emit, newDoc, oldDoc, userCtx, secObj */
+/*eslint no-unused-vars: ["error", { "vars": "local", "argsIgnorePattern": "newDoc|oldDoc|userCtx|secObj" }]*/
+
+"use strict";
+
+require("infusion");
+fluid.setLogging(true);
+var sjrk = fluid.registerNamespace("sjrk");
+
+require("../../singleNodeConfiguration");
+require("./floe_stories_0.3.0_to_0.4.0_documents");
+
+
+// Mix-in grade for all the couch configuration
+// components when actually used to configure
+// the DB
+fluid.defaults("sjrk.storyTelling.server.dbSetup.core", {
+    distributeOptions: [
+        {
+            target: "{that}.options.couchOptions.couchUrl",
+            record: "@expand:kettle.resolvers.env(COUCHDB_URL)"
+        },
+        {
+            target: "{that}.options.components.retryingBehaviour.options.retryOptions.maxRetries",
+            record: "@expand:kettle.resolvers.env(COUCHDB_CONFIG_MAX_RETRIES)"
+        },
+        {
+            target: "{that}.options.components.retryingBehaviour.options.retryOptions.retryDelay",
+            record: "@expand:kettle.resolvers.env(COUCHDB_CONFIG_RETRY_DELAY)"
+        }
+    ],
+    listeners: {
+        "onCreate.configureCouch": "{that}.configureCouch"
+    }
+});
+
+// sets up a new instance of the core setup along with replicatorDb defined
+sjrk.storyTelling.server.replicatorDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with usersDb defined
+sjrk.storyTelling.server.usersDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with globalChangesDb defined
+sjrk.storyTelling.server.globalChangesDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with the storiesDb defined
+sjrk.storyTelling.server.storiesDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});

--- a/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/karisma_stories_0.3.0_to_0.4.0_documents.js
+++ b/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/karisma_stories_0.3.0_to_0.4.0_documents.js
@@ -1,0 +1,359 @@
+/*
+For copyright information, see the AUTHORS.md file in the docs directory of this distribution and at
+https://github.com/fluid-project/sjrk-story-telling/blob/main/docs/AUTHORS.md
+
+Licensed under the New BSD license. You may not use this file except in compliance with this licence.
+You may obtain a copy of the BSD License at
+https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.txt
+*/
+
+// These eslint directives prevent the linter from complaining about the use of
+// globals or arguments that will be prevent in CouchDB design doc functions
+// such as views or validate_doc_update
+
+"use strict";
+
+require("infusion");
+require("kettle");
+
+require("fluid-couch-config");
+
+// sets up the Storytelling Tool database migration using fluid-couch-config
+fluid.defaults("sjrk.storyTelling.server.storiesDb", {
+    gradeNames: ["fluid.couchConfig.pipeline.retrying"],
+    couchOptions: {
+        dbName: "stories"
+    },
+    listeners: {
+        "onSuccess.logSuccess": "fluid.log(SUCCESS)",
+        "onError.logError": "fluid.log({arguments}.0.message)"
+    },
+    dbDocuments: {
+        "0087d6f0-6115-11e8-9250-0b33877004ce": {
+            "type": "story",
+            "value": {
+                "id": "0087d6f0-6115-11e8-9250-0b33877004ce",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Viaje a Medellín",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Salimos de fresno a la 1:00 am el dia jueves, descansamos un poco en el camino nos dieron refrigerio luego llegamos a medellín a las 8:30 am, tuvimos un paseo visitando varios espacios de medellín muy maravillosos, luego del paseo fuimos a platohedro un lugar maravilloso donde hay personas super maravillosas que no recibieron con gran cariño nos atendieron de una manera muy agradable. Hoy dia viernes tuvimos un taller para tener creatividad y conocimiento donde las pasamos muy chevere y tuvimos una conexion con una chica de cartagena llamada natalia."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/00840660-6115-11e8-9250-0b33877004ce.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1527360055164,
+                            "lastModifiedDate": "2018-05-26T18:40:55.164Z",
+                            "name": "claudia foto 5.jpg",
+                            "size": 129499,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/00847b90-6115-11e8-9250-0b33877004ce.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1527304111601,
+                            "lastModifiedDate": "2018-05-26T03:08:31.601Z",
+                            "name": "claudia foto 1.jpg",
+                            "size": 106676,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/008517d0-6115-11e8-9250-0b33877004ce.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1527304111611,
+                            "lastModifiedDate": "2018-05-26T03:08:31.611Z",
+                            "name": "claudia foto 2.jpg",
+                            "size": 80795,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/008565f0-6115-11e8-9250-0b33877004ce.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1527304111619,
+                            "lastModifiedDate": "2018-05-26T03:08:31.619Z",
+                            "name": "claudia foto 3.jpg",
+                            "size": 78825,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/00858d00-6115-11e8-9250-0b33877004ce.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1527304111628,
+                            "lastModifiedDate": "2018-05-26T03:08:31.628Z",
+                            "name": "claudia foto 4.jpg",
+                            "size": 91466,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "author": "grupo Real campestre la sagrada familia \"Fresno Tolima\"",
+                "tags": [
+                    "Medellín",
+                    "platohedro"
+                ]
+            }
+        },
+        "7c9c5490-608f-11e8-9250-0b33877004ce": {
+            "type": "story",
+            "value": {
+                "id": "7c9c5490-608f-11e8-9250-0b33877004ce",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Dana y Michell",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/7c9a58c0-608f-11e8-9250-0b33877004ce.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1527302830170,
+                            "lastModifiedDate": "2018-05-26T02:47:10.170Z",
+                            "name": "dana y michell.jpg",
+                            "size": 159762,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Ellas unas chicas super cheberes las cuales nos enseñaron muchisimas cosas y nos divertimos demasiado gracias."
+                    }
+                ],
+                "author": "Camila Lucas",
+                "tags": [
+                    "Diseño inclusivo"
+                ]
+            }
+        },
+        "8c7a2700-603c-11e8-a437-e32071306bc8": {
+            "type": "story",
+            "value": {
+                "id": "8c7a2700-603c-11e8-a437-e32071306bc8",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Pajaro",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "introducíon",
+                        "blockType": "text",
+                        "text": "una historia bonita"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "kinglet",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/8c778ef0-603c-11e8-a437-e32071306bc8.jpg",
+                        "alternativeText": "pajaro",
+                        "description": "pajaro pequeño con amarillo",
+                        "fileDetails": {
+                            "lastModified": 1524251899736,
+                            "lastModifiedDate": "2018-04-20T19:18:19.736Z",
+                            "name": "little bird 1.jpg",
+                            "size": 364528,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "author": "Dana",
+                "tags": [
+                    "pajaro",
+                    "amarillo",
+                    "historia"
+                ]
+            }
+        },
+        "ab327d10-6090-11e8-9250-0b33877004ce": {
+            "type": "story",
+            "value": {
+                "id": "ab327d10-6090-11e8-9250-0b33877004ce",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Dana y Michell",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/ab31e0d0-6090-11e8-9250-0b33877004ce.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1527303304585,
+                            "lastModifiedDate": "2018-05-26T02:55:04.585Z",
+                            "name": "juan foto 1.jpg",
+                            "size": 80542,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Una reunión super chévere entretenida y Dana, Michell son super"
+                    }
+                ],
+                "author": "Juan Sebatian",
+                "tags": [
+                    "Diseño inclusivo"
+                ]
+            }
+        },
+        "c62f00b0-6041-11e8-a437-e32071306bc8": {
+            "type": "story",
+            "value": {
+                "id": "c62f00b0-6041-11e8-a437-e32071306bc8",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Aprendiendo ando en medellin",
+                "content": [],
+                "author": "Giovanna Marcela Ramirez Romero ",
+                "tags": [
+                    "Jóvenes karisma"
+                ]
+            }
+        },
+        "dca39580-6092-11e8-9250-0b33877004ce": {
+            "type": "story",
+            "value": {
+                "id": "dca39580-6092-11e8-9250-0b33877004ce",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Viaje a medellín",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Salimos de fresno a la 1:00 am el dia jueves, descansamos un poco en el camino nos dieron refrigerio luego llegamos a medellín a las 8:30 am, tuvimos un paseo visitando varios espacios de medellín muy maravillosos, luego del paseo fuimos a platohedro un lugar maravilloso donde hay personas super maravillosas que no recibieron con gran cariño nos atendieron de una manera muy agradable. Hoy dia viernes tuvimos un taller para tener creatividad y conocimiento donde las pasamos muy chevere y tuvimos una conexion con una chica de cartagena llamada natalia."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/dca0af50-6092-11e8-9250-0b33877004ce.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1527304111601,
+                            "lastModifiedDate": "2018-05-26T03:08:31.601Z",
+                            "name": "claudia foto 1.jpg",
+                            "size": 106676,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/dca12480-6092-11e8-9250-0b33877004ce.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1527304111611,
+                            "lastModifiedDate": "2018-05-26T03:08:31.611Z",
+                            "name": "claudia foto 2.jpg",
+                            "size": 80795,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/dca172a0-6092-11e8-9250-0b33877004ce.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1527304111619,
+                            "lastModifiedDate": "2018-05-26T03:08:31.619Z",
+                            "name": "claudia foto 3.jpg",
+                            "size": 78825,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/dca199b0-6092-11e8-9250-0b33877004ce.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1527304111628,
+                            "lastModifiedDate": "2018-05-26T03:08:31.628Z",
+                            "name": "claudia foto 4.jpg",
+                            "size": 91466,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "author": "Claudia Ariza",
+                "tags": [
+                    "Medellín",
+                    "platohedro"
+                ]
+            }
+        }
+    }
+});

--- a/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/karisma_stories_0.3.0_to_0.4.0_migration.js
+++ b/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/karisma_stories_0.3.0_to_0.4.0_migration.js
@@ -1,0 +1,68 @@
+/*
+For copyright information, see the AUTHORS.md file in the docs directory of this distribution and at
+https://github.com/fluid-project/sjrk-story-telling/blob/main/docs/AUTHORS.md
+
+Licensed under the New BSD license. You may not use this file except in compliance with this licence.
+You may obtain a copy of the BSD License at
+https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.txt
+*/
+
+// These eslint directives prevent the linter from complaining about the use of
+// globals or arguments that will be prevent in CouchDB design doc functions
+// such as views or validate_doc_update
+
+/* global sjrk, emit, newDoc, oldDoc, userCtx, secObj */
+/*eslint no-unused-vars: ["error", { "vars": "local", "argsIgnorePattern": "newDoc|oldDoc|userCtx|secObj" }]*/
+
+"use strict";
+
+require("infusion");
+fluid.setLogging(true);
+var sjrk = fluid.registerNamespace("sjrk");
+
+require("../../singleNodeConfiguration");
+require("./karisma_stories_0.3.0_to_0.4.0_documents");
+
+
+// Mix-in grade for all the couch configuration
+// components when actually used to configure
+// the DB
+fluid.defaults("sjrk.storyTelling.server.dbSetup.core", {
+    distributeOptions: [
+        {
+            target: "{that}.options.couchOptions.couchUrl",
+            record: "@expand:kettle.resolvers.env(COUCHDB_URL)"
+        },
+        {
+            target: "{that}.options.components.retryingBehaviour.options.retryOptions.maxRetries",
+            record: "@expand:kettle.resolvers.env(COUCHDB_CONFIG_MAX_RETRIES)"
+        },
+        {
+            target: "{that}.options.components.retryingBehaviour.options.retryOptions.retryDelay",
+            record: "@expand:kettle.resolvers.env(COUCHDB_CONFIG_RETRY_DELAY)"
+        }
+    ],
+    listeners: {
+        "onCreate.configureCouch": "{that}.configureCouch"
+    }
+});
+
+// sets up a new instance of the core setup along with replicatorDb defined
+sjrk.storyTelling.server.replicatorDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with usersDb defined
+sjrk.storyTelling.server.usersDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with globalChangesDb defined
+sjrk.storyTelling.server.globalChangesDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with the storiesDb defined
+sjrk.storyTelling.server.storiesDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});

--- a/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/sojustrepairit_stories_0.3.0_to_0.4.0_documents.js
+++ b/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/sojustrepairit_stories_0.3.0_to_0.4.0_documents.js
@@ -1,0 +1,1917 @@
+/*
+For copyright information, see the AUTHORS.md file in the docs directory of this distribution and at
+https://github.com/fluid-project/sjrk-story-telling/blob/main/docs/AUTHORS.md
+
+Licensed under the New BSD license. You may not use this file except in compliance with this licence.
+You may obtain a copy of the BSD License at
+https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.txt
+*/
+
+// These eslint directives prevent the linter from complaining about the use of
+// globals or arguments that will be prevent in CouchDB design doc functions
+// such as views or validate_doc_update
+
+"use strict";
+
+require("infusion");
+require("kettle");
+
+require("fluid-couch-config");
+
+// sets up the Storytelling Tool database migration using fluid-couch-config
+fluid.defaults("sjrk.storyTelling.server.storiesDb", {
+    gradeNames: ["fluid.couchConfig.pipeline.retrying"],
+    couchOptions: {
+        dbName: "stories"
+    },
+    listeners: {
+        "onSuccess.logSuccess": "fluid.log(SUCCESS)",
+        "onError.logError": "fluid.log({arguments}.0.message)"
+    },
+    dbDocuments: {
+        "2355da60-f11f-11e9-9409-319b90678833": {
+            "type": "story",
+            "value": {
+                "id": "2355da60-f11f-11e9-9409-319b90678833",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "In May 2018, a group of high school students from Fresno, a small town in the mountains of Colombia, visited the city of Medellín for the first time. They traveled 7 hours by bus to participate in a 3 days event to share experiences and ideas with a group of young women that are interested in sovereignty, technologies, and gender. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Arriving at Medellín",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/22d511a0-f11f-11e9-9409-319b90678833.jpg",
+                        "alternativeText": "A group of people (4 adults and 2 teenagers) are showing to the camera a box full of fruits and groceries. ",
+                        "description": "A group of people is showing to the camera a box full of fruits and groceries. ",
+                        "fileDetails": {
+                            "lastModified": 1571344794000,
+                            "lastModifiedDate": "2019-10-17T20:39:54.000Z",
+                            "name": "A_imagen1_llegada_medellin.jpg",
+                            "size": 601955,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "All the details were ready for this great encounter between two generations of young people with very different contexts and backgrounds. The venue for this event was the house of Platohedro, a very special place where art and technologies are the bases to create collaborative and experimental projects.\n\nThe group of young women from Medellín has a project named “Motivando a la Gyal” (M.A.G)*. A women-led platform that runs a Festival every year. M.A.G group was nervous because this was the first time they prepare an activity like this, an activity for a group of young people that came from the countryside. They wanted to offer an amazing agenda to the boys and girls from Fresno, so they can feel comfortable, safe and happy. And that was exactly what happened. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Gender workshop",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/22d5fc00-f11f-11e9-9409-319b90678833.jpg",
+                        "alternativeText": "A group of people is listening to a person that is talking to them. The groups is sat and look calm.",
+                        "description": "A group of people is listening to a person that is talking to them. ",
+                        "fileDetails": {
+                            "lastModified": 1571344918000,
+                            "lastModifiedDate": "2019-10-17T20:41:58.000Z",
+                            "name": "B_talleres_genero.jpg",
+                            "size": 1489338,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "During 3 days they realized that all of them want it to take care of the environment and that they are working on that though their projects in the school and with the Festival."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Orchards",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/22d7a9b0-f11f-11e9-9409-319b90678833.JPG",
+                        "alternativeText": "A group of people is surrounding an orchard. They mostly women. Some of them look like they are talking, some are standing with their cell phones.",
+                        "description": "A group of people is surrounding an orchard",
+                        "fileDetails": {
+                            "lastModified": 1571344960000,
+                            "lastModifiedDate": "2019-10-17T20:42:40.000Z",
+                            "name": "C_huerta.JPG",
+                            "size": 2563179,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "They visited the Manga Libre and other community orchards in Medellín and share knowledge about plants, herbs and about products like “panela” that are produced from sugarcane. The young girls from M.A.G were surprised about all the knowledge that the students from Fresno have about the work on the farms. For the students, the idea of having an orchard in the middle of the city was surprising as well because they are used to living in large extensions of land in a very rich and fertile territory."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Panela",
+                        "mediaUrl": "./uploads/22dba150-f11f-11e9-9409-319b90678833.mp4",
+                        "alternativeText": null,
+                        "description": "A woman and a young woman talked about why panela has different tones. ",
+                        "blockType": "video",
+                        "fileDetails": {
+                            "lastModified": 1571345015000,
+                            "lastModifiedDate": "2019-10-17T20:43:35.000Z",
+                            "name": "D_explicacion_panela.mp4",
+                            "size": 151267437,
+                            "type": "video/mp4"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "During 3 days the participants of the event to share ideas about inclusiveness, gender, care, seeds, environment and learn a lot about the differences and the struggles that the people that live in the cities and those who live in the countryside have in common."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Enjoying Medellín",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/235405a0-f11f-11e9-9409-319b90678833.png",
+                        "alternativeText": "A black and white picture of a group of people, mostly young people that are playing around a water fountain.",
+                        "description": "A group of people, mostly young people are playing around a water fountain.",
+                        "fileDetails": {
+                            "lastModified": 1571345061000,
+                            "lastModifiedDate": "2019-10-17T20:44:21.000Z",
+                            "name": "E_disfrutando_medellin.png",
+                            "size": 397113,
+                            "type": "image/png"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "A new planet was discovered during those 3 days. A planet of sharing, listening and exchanging. A planet that is a school. \n\n*slang for “girl”."
+                    }
+                ],
+                "title": "A new planet discovered",
+                "author": "",
+                "tags": []
+            }
+        },
+        "23a61a00-07d8-11ea-a5cf-99a2338da816": {
+            "type": "story",
+            "value": {
+                "id": "23a61a00-07d8-11ea-a5cf-99a2338da816",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "ENVIRONMENTAL GUARD IN 2016…",
+                        "blockType": "text",
+                        "text": "When the project began with the Environmental Guard, an institution was found with desires and dreams that were not developed, which from their possibilities were looking for ways to achieve them.\n\nWe wanted to reach communities and people who, due to the structural and resource conditions, were not able to educate and train Environmental Guards. For example, it was very difficult to educate and train young people in cities far from Cartagena or in other departments.\n\nFor this reason it was important to make use of technological tools that would facilitate this purpose."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "COLOMBIAN ENVIRONMENTAL GUARD",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/2397c220-07d8-11ea-a5cf-99a2338da816.jpg",
+                        "alternativeText": "Group of Environmental Guardians in the city of Cartagena de Indias.",
+                        "description": "Group of Environmental Guardians in the city of Cartagena de Indias. This photo was taken in the Canapote neighborhood on July 20, 2015",
+                        "fileDetails": {
+                            "lastModified": 1572994316525,
+                            "lastModifiedDate": "2019-11-05T22:51:56.525Z",
+                            "name": "1.jpg",
+                            "size": 314497,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Video of the Colombian Environmental Guard",
+                        "blockType": "text",
+                        "text": "[https://youtu.be/6ugHF1YqNWc](https://youtu.be/6ugHF1YqNWc)"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "WHAT WE ACHIEVE WITH SJRK",
+                        "blockType": "text",
+                        "text": "We want to tell you the most important thing we have built together with the SJRK project team:\n\nFirst, we created the web page http://guardiaambiental.org/ with custom visualization tools that have allowed us to show what we do in a digital range with more influence and for all people, being an accessible page.\n\nThe introduction of technological tools such as the MOOC and the visualization of environmental data of the city of Cartagena on the website has allowed us to expand the number of young people interested and trained as Environmental Guards who are providing management in the recovery of their environment.\n\nThe production of videos in Cuentalo, a very rewarding experience, by which we got to know stories and experiences of our young people who for many years were developing environmental guard activities, but we did not know why they were interested and, beyond that, all the social and family conditions to which they had been exposed.\n\nThe inclusion workshops, which taught us how we can make it easier for all people, including those with disabilities, to develop activities that recover and conserve the environment.\n\nThe internationalization of the Environmental Guard, through the visibility of the activities of the Guard in social media, the exchange of ideas and experiences with countries such as Italy, Brazil, Mexico, international visits to OCAD University in Toronto, by the Director Roberto Ruiz and the General Coordinator of Volunteers Elbert Rocha and the planning of a project to establish the Environmental Guard in Canada."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/239921b0-07d8-11ea-a5cf-99a2338da816.png",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1572994319681,
+                            "lastModifiedDate": "2019-11-05T22:51:59.681Z",
+                            "name": "2.png",
+                            "size": 5322159,
+                            "type": "image/png"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "How the Colombian Environmental Guard works",
+                        "blockType": "text",
+                        "text": "[https://youtu.be/X_Fw2Ud1cms](https://youtu.be/X_Fw2Ud1cms)"
+                    }
+                ],
+                "title": "Story of the participation of the Colombian Environmental Guard in the SJRK project",
+                "author": "",
+                "tags": [
+                    "Guardia Ambiental",
+                    "SJRK",
+                    "Cartagena",
+                    "Environmental Guard"
+                ]
+            }
+        },
+        "525c1950-f09d-11e9-8299-d34aa606fc6a": {
+            "type": "story",
+            "value": {
+                "id": "525c1950-f09d-11e9-8299-d34aa606fc6a",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Salimos de fresno a la 1:00 am el dia jueves, descansamos un poco en el camino nos dieron refrigerio luego llegamos a medellín a las 8:30 am, tuvimos un paseo visitando varios espacios de medellín muy maravillosos, luego del paseo fuimos a platohedro un lugar maravilloso donde hay personas super maravillosas que no recibieron con gran cariño nos atendieron de una manera muy agradable. Hoy dia viernes tuvimos un taller para tener creatividad y conocimiento donde las pasamos muy chevere y tuvimos una conexion con una chica de cartagena llamada natalia."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/5258e500-f09d-11e9-8299-d34aa606fc6a.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1571289126992,
+                            "lastModifiedDate": "2019-10-17T05:12:06.992Z",
+                            "name": "1.jpg",
+                            "size": 129499,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/52593320-f09d-11e9-8299-d34aa606fc6a.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1571289131489,
+                            "lastModifiedDate": "2019-10-17T05:12:11.489Z",
+                            "name": "2.jpg",
+                            "size": 106676,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/5259f670-f09d-11e9-8299-d34aa606fc6a.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1571289134884,
+                            "lastModifiedDate": "2019-10-17T05:12:14.884Z",
+                            "name": "3.jpg",
+                            "size": 80795,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/525a4490-f09d-11e9-8299-d34aa606fc6a.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1571289137984,
+                            "lastModifiedDate": "2019-10-17T05:12:17.984Z",
+                            "name": "4.jpg",
+                            "size": 78825,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/525a92b0-f09d-11e9-8299-d34aa606fc6a.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1571289141817,
+                            "lastModifiedDate": "2019-10-17T05:12:21.817Z",
+                            "name": "5.jpg",
+                            "size": 91466,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "title": "Viaje a Medellín",
+                "author": "grupo Real campestre la sagrada familia \"Fresno Tolima\"",
+                "tags": [
+                    "Medellín",
+                    "platohedro"
+                ]
+            }
+        },
+        "529a3ce0-f123-11e9-9409-319b90678833": {
+            "type": "story",
+            "value": {
+                "id": "529a3ce0-f123-11e9-9409-319b90678833",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "CONTEXTUALIZACIÓN",
+                        "blockType": "text",
+                        "text": "La ciudad de Cartagena – Colombia, cuenta con una población cercana a 1.036.412 habitantes según la proyección de población municipal por área desarrollada por el DANE, de los cuales 269.442 son jóvenes entre 14 y 28 años, quienes representan el 26,29% de la población general. Destacamos que la mayoría de estos jóvenes son afrodescendiente y la mayoría desconoce los niveles de realización de sus derechos, viviendo situaciones de desigualdad e injusticia social.\n\nEn el proyecto social justice repair kit buscamos entonces dar a conocer la diversidad social en la ciudad de Cartagena a través de la narración de historias de vidas significativas y positivas de jóvenes que viven en la ciudad, y en este sentido, fue muy importante contactar a los jóvenes, grupos u organizaciones juveniles que desarrollaran un activismo social, cultural o político en la ciudad.\n\nPara el proyecto no fue fácil identificar las organizaciones o grupos juveniles que desarrollan un activismo cultural, social o político en la ciudad. Por una parte, las institución del gobierno encargada de trabajar con los jóvenes no tenía en ese momento una base de datos con la información actualizada de los jóvenes, nos tocó utilizar la técnica bola de nieve partiendo de la información que teníamos de algunos grupos o jóvenes contactados, los que nos referían a otros y así logramas contactar varios de ellos. Esta situación le dio relevancia a las acciones desarrolladas desde el proyecto y pensar acciones que contribuyan a subsanar ese problema ..*la falta de información (oportuna, veraz, confiable) acerca de los grupos juveniles de la ciudad.."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "CONTANDO LAS HISTORIAS",
+                        "blockType": "text",
+                        "text": "Los jóvenes que contaron sus historias tienen en común situaciones de desigualdad social y política, y para hacer frente a esto movilizan recursos propios y comunitarios para promover la garantía de derechos de los jóvenes de su comunidad. Esta labor que no es fácil, es producto de la fragmentación y polarización social manifiesta por la apatía e indiferencia de algunos jóvenes frente a la defensa de sus derechos. \n\nPor lo anterior los jóvenes reconocen en contar sus historias una herramienta valiosa para dar a conocer que somos diferentes, reconociendo en el otro experiencias de vida que le permitieron salir adelante a pesar de las dificultades o problemas, siendo inspirador para otros jóvenes.\n\nPara dar visibilidad a las historias desde el proyecto se creó una plataforma virtual que se llama “cuéntalo.org” posibilitando tener datos oportunos y confiables de los jóvenes u organizaciones juveniles que desarrollan un activismo social, dando a conocer el tipo de actividad que realizan, población con la que trabajan, ubicación entre otras.."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "APRENDIZAJES",
+                        "blockType": "text",
+                        "text": "En el desarrollo del proyecto aprendimos la importancia de la articulación de las diferentes disciplinas en la consecución de un objetivo en común y en este caso de carácter social… profesionales en la realización audiovisual, ingeniería de sistemas, psicología entre otros articulamos saberes en la identificación, formulación y elaboración de las historias siendo los jóvenes protagonistas activos y el eje central articulados de las acciones …"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Social Justice Repair Kit",
+                        "blockType": "text",
+                        "text": "Presentación del equipo SJRK\n[https://www.youtube.com/watch?v=1fxQqDWaDW8&t=6s](https://www.youtube.com/watch?v=1fxQqDWaDW8&t=6s)"
+                    }
+                ],
+                "title": "SJRK CARTAGENA, our story …. ",
+                "author": "Amaury",
+                "tags": []
+            }
+        },
+        "58159990-f76c-11e9-9f47-0d8885ce50a7": {
+            "type": "story",
+            "value": {
+                "id": "58159990-f76c-11e9-9f47-0d8885ce50a7",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Throughout the SJRK project, our organization has collaborated with many initiatives that are advancing programming for people with disabilities. Designing inclusively, to support people who have different needs than your own can be challenging, as sometimes differing needs and the accommodations to overcome them may not be obvious. Being open, collaborative, humble and iterative can help when there is no good way to anticipate how to ensure delivery in an inclusive way.\n\nOne story I have in this realm relates to a training that I conducted for 40 deaf language instructors as part of a collaborative training program. As a very novice practitioner of ASL and one of the very few hearing people in the room, it was fascinating to experience a context where the medical model of disability (where “the individual is seen as the problem”) and the social model of disability (where “social barriers are the problem”) was so apparent to me. \n\nI, for the first time in my experience, was very much disadvantaged by the context, a community of folks who I had previously understood to be at a disadvantage. Here, in the room, my inability to understand ASL put me at a disadvantage in being able to communicate with and understand the community of ASL native speakers.\n\nThere were interpreters available, which were heavily relied upon to both understand and respond to questions and content throughout the training.\n\nThis training flipped me and my perspective on my head. I walked into the room as a hearing person, and left the room as an incompetent user of ASL. The difference was merely a change of perspective. I was very appreciative of the opportunity to learn, share and engage with the deaf community and I revealed so much about my own assumptions through the experience. \n"
+                    }
+                ],
+                "title": "Medical and Social models",
+                "author": "TIG",
+                "tags": [
+                    "SJRK",
+                    "TIG",
+                    "medical model",
+                    "social model"
+                ]
+            }
+        },
+        "65651980-f146-11e9-9409-319b90678833": {
+            "type": "story",
+            "value": {
+                "id": "65651980-f146-11e9-9409-319b90678833",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Remembering What It's All For",
+                        "blockType": "text",
+                        "text": "Working with partners far and wide on the SJRK project has been a wonderful experience for me as I have learned so much about places, cultures and contexts that were previously unfamiliar to me. I am grateful to be able to use technology to stay connected with one another, but coming together in the same place is always a powerful reminder for me of why this work is important. Gathering together in the same room, as we did today, to share stories about the project and to reflect on our successes and challenges has reinvigorated me and made me excited to start scheming about what will come next!"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/656085a0-f146-11e9-9409-319b90678833.jpg",
+                        "alternativeText": "A photo of a group of 9 people standing, sitting and squatting against a white wall, with two drawings on brown paper taped to the wall behind them.",
+                        "description": "Group photo (with guest \"creatures\"), SJRK face to face meeting, October 17, 2019",
+                        "fileDetails": {
+                            "lastModified": 1571361062324,
+                            "lastModifiedDate": "2019-10-18T01:11:02.324Z",
+                            "name": "group photo oct 17 2019.jpg",
+                            "size": 277789,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Gratitude",
+                        "blockType": "text",
+                        "text": "I'm grateful to all of the partners for bringing your incredible knowledge and experience to this project, and for your willingness to enter into an unknown space with us where we could explore possibilities together. Congratulations to all for a successful project!"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/656148f0-f146-11e9-9409-319b90678833.jpg",
+                        "alternativeText": "A photo of people sitting in a circle, including an image of someone on a large computer screen and one person standing up, in a room with a red wall and red carpet.",
+                        "description": "Face to face meeting discussion",
+                        "fileDetails": {
+                            "lastModified": 1571361559094,
+                            "lastModifiedDate": "2019-10-18T01:19:19.094Z",
+                            "name": "group action shot 1.jpg",
+                            "size": 279969,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/6561e530-f146-11e9-9409-319b90678833.jpg",
+                        "alternativeText": "A photo of people sitting in a circle in a room with a red wall and red carpet.",
+                        "description": "Face to face meeting discussion ",
+                        "fileDetails": {
+                            "lastModified": 1571361580137,
+                            "lastModifiedDate": "2019-10-18T01:19:40.137Z",
+                            "name": "group action shot 2.jpg",
+                            "size": 301513,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "title": "What It's All About",
+                "author": "Dana ",
+                "tags": [
+                    "SJRK",
+                    "partners",
+                    "collaboration",
+                    "international",
+                    "gratitude",
+                    "exploration"
+                ]
+            }
+        },
+        "6770a110-00d5-11ea-addf-fb8afee817da": {
+            "type": "story",
+            "value": {
+                "id": "6770a110-00d5-11ea-addf-fb8afee817da",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "We left Fresno at 1:00 AM on Thursday, we rested a little on the road, they gave us refreshments, then we arrived in Medellin at 8:30 AM. We had a walk visiting several very wonderful areas of Medellin. After the walk we went to platohedro, a wonderful place where there are super wonderful people who received us with great affection and attended to us in a very nice way. Today, Friday, we had a workshop to promote creativity and knowledge where we had a great time and made a connection with a girl from Cartagena called Natalia."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/676b9800-00d5-11ea-addf-fb8afee817da.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1572992844269,
+                            "lastModifiedDate": "2019-11-05T22:27:24.269Z",
+                            "name": "1.jpg",
+                            "size": 129499,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/676c5b50-00d5-11ea-addf-fb8afee817da.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1572992847717,
+                            "lastModifiedDate": "2019-11-05T22:27:27.717Z",
+                            "name": "2.jpg",
+                            "size": 106676,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/676cd080-00d5-11ea-addf-fb8afee817da.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1572992851527,
+                            "lastModifiedDate": "2019-11-05T22:27:31.527Z",
+                            "name": "3.jpg",
+                            "size": 80795,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/676d1ea0-00d5-11ea-addf-fb8afee817da.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1572992856800,
+                            "lastModifiedDate": "2019-11-05T22:27:36.800Z",
+                            "name": "4.jpg",
+                            "size": 78825,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/676d93d0-00d5-11ea-addf-fb8afee817da.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1572992860051,
+                            "lastModifiedDate": "2019-11-05T22:27:40.051Z",
+                            "name": "5.jpg",
+                            "size": 91466,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "title": "Trip to Medellin",
+                "author": "grupo Real campestre la sagrada familia \"Fresno Tolima\"",
+                "tags": [
+                    "Medellín",
+                    "platohedro"
+                ]
+            }
+        },
+        "6fa874c0-f11c-11e9-9409-319b90678833": {
+            "type": "story",
+            "value": {
+                "id": "6fa874c0-f11c-11e9-9409-319b90678833",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Ivan de la Montaña, thought of a workshop for young people to know where they lived, what were the stories that surrounded them as a community, and why it was important to know them. Using a map and activities, young people would know more about Fresno."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "In the workshop",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/6f5ffa10-f11c-11e9-9409-319b90678833.png",
+                        "alternativeText": "A group of students sitting in a semi-circle, and one teacher. Some of them have their hands over their faces, others have their eyes closed.",
+                        "description": "The workshop in progress. Students are deep in thought.",
+                        "fileDetails": {
+                            "lastModified": 1571343680000,
+                            "lastModifiedDate": "2019-10-17T20:21:20.000Z",
+                            "name": "Taller 1 Toronto.png",
+                            "size": 774725,
+                            "type": "image/png"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Alejandra is a restless woman, curious, full of life, with many ideas. She was making with her cell phone and little budget, audiovisual material about Fresno, . She showed us a documentary she was doing to show the territory."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "lecturer and map",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/6f61f5e0-f11c-11e9-9409-319b90678833.png",
+                        "alternativeText": "The left side of the image has a man’s face with some green mountains in the background. On the right side is a hand-drawn map showing the region of Tulaymá",
+                        "description": "Lecturer and map used in the workshop",
+                        "fileDetails": {
+                            "lastModified": 1571343741000,
+                            "lastModifiedDate": "2019-10-17T20:22:21.000Z",
+                            "name": "taller 2 Toronto.png",
+                            "size": 864454,
+                            "type": "image/png"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "We asked both of them to do an audiovisual workshop where they would teach young people to develop ideas using what they had. Show that technology was available, they could use the cell phone, to which many had access, to tell a story. They would have to meet, think of an idea, develop it and then take advantage of the Local network to spread it."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Cellphone and recording",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/6f63a390-f11c-11e9-9409-319b90678833.png",
+                        "alternativeText": "A cellular phone being used to capture a photo of a small sculpture of a person made out of plant material and wire.",
+                        "description": "Cellphone recording image",
+                        "fileDetails": {
+                            "lastModified": 1571343793000,
+                            "lastModifiedDate": "2019-10-17T20:23:13.000Z",
+                            "name": "taller 3 Toronto.png",
+                            "size": 784681,
+                            "type": "image/png"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Alejandra finishes the workshop and immediately the students tell her that they have an idea about a short film in which they want to teach the rest of the school about bullying, leaving the short in the Local Network so that the other students can see it. They ask you not to leave because they would like you to help them, it is 2:00 pm in the afternoon and the last bus leaves at 4:00 pm. Alejandra does not doubt it and tells them that time must be planned.\n\nFinally, jointly they create a script, share the characters, share roles and start recording, create “ El Pecas” (The \"Freckles\")."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Video Pecas",
+                        "mediaUrl": "./uploads/6f64dc10-f11c-11e9-9409-319b90678833.mp4",
+                        "alternativeText": null,
+                        "description": "Video about bullying",
+                        "blockType": "video",
+                        "fileDetails": {
+                            "lastModified": 1571343858000,
+                            "lastModifiedDate": "2019-10-17T20:24:18.000Z",
+                            "name": "Taller 4 PECAS.mp4",
+                            "size": 51477992,
+                            "type": "video/mp4"
+                        }
+                    }
+                ],
+                "title": "Audiovisual Workshop",
+                "author": "",
+                "tags": []
+            }
+        },
+        "7810c740-f11a-11e9-9409-319b90678833": {
+            "type": "story",
+            "value": {
+                "id": "7810c740-f11a-11e9-9409-319b90678833",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "I joined the IDRC in July of 2017, shortly after the start of the SJRK project. I've been the primary developer of the Storytelling Tool in collaboration with at least a half-dozen other developers and designers. The evolution of the tool over the last two and a bit years has given me a greater appreciation for the challenges of designing and developing a web app that was as inclusive and accessible as possible, both in terms of its use and also its creation.\n\nPart of this creation was in fact co-creation and co-design along with the various SJRK partners around the globe. I learned about the invaluable benefit of gathering a diversity of perspectives and experiences, and that no one designer or developer could possibly know what will work best for every user. I heard about students in Rwanda with learning differences; a group youth movement in Colombia that taught others to care for their local environment; another group in Colombia developing a wide area network where there was little to no connectivity to the broader internet; setting up an online high school in Mexico for students who would otherwise not be able to attend; a team teaching youth in Canada's North how to use video cameras and drones to share their experiences."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/780b7010-f11a-11e9-9409-319b90678833.png",
+                        "alternativeText": "A very basic web design consisting primarily of a page title, a large text input box and a button that says \"Done\", all in black on a white background",
+                        "description": "One of the first designs of The Storytelling Tool",
+                        "fileDetails": {
+                            "lastModified": 1571342652000,
+                            "lastModifiedDate": "2019-10-17T20:04:12.000Z",
+                            "name": "2019-10-17 storytelling tool story - design 1.png",
+                            "size": 36351,
+                            "type": "image/png"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Learning about all the amazing projects being supported was awe-inspiring. When I began to work on the Storytelling Tool, I had an abstract sense of what it would be used for, though I didn't know at that point the full breadth of work being done by the partner organizations. To find out that we were in the company of groups working so hard to improve the lives and access to education for young people was so inspiring, and gave me motivation to do my best in working on tool."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/780bbe30-f11a-11e9-9409-319b90678833.png",
+                        "alternativeText": "A simple web interface with no decorative elements consisting of a form with various fields. The fields include: \"story title\", \"your name\", a text input area, a drop-down list to indicate the language of the story and a text box to enter the language, and finally a button that says \"Done\" ",
+                        "description": "An early prototype of the tool with basic multilingual features and only supporting text stories",
+                        "fileDetails": {
+                            "lastModified": 1571342674000,
+                            "lastModifiedDate": "2019-10-17T20:04:34.000Z",
+                            "name": "2019-10-17 storytelling tool story - tool 1.png",
+                            "size": 56790,
+                            "type": "image/png"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "A simple web interface with no decorative elements consisting of a form with various fields. The fields include: \"story title\", \"your name\", a text input area, a drop-down list to indicate the language of the story and a text box to enter the language, and finally a button that says \"Done\" "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/780c0c50-f11a-11e9-9409-319b90678833.png",
+                        "alternativeText": null,
+                        "description": "the first appearance of the \"block\" based authoring systema series of design mockups of the storytelling tool, each consisting of a title bar in yellow with a few buttons below it to add various types of block to the story. The icons on the buttons include a letter T, an image, a paintbrush, a microphone and a video camera. In further screens, a text area is present and an on-screen keyboard is shown",
+                        "fileDetails": {
+                            "lastModified": 1571342668000,
+                            "lastModifiedDate": "2019-10-17T20:04:28.000Z",
+                            "name": "2019-10-17 storytelling tool story - design 2.png",
+                            "size": 195255,
+                            "type": "image/png"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "There were times where I would get so deep into the weeds of the code that I lost sight of the end goal of creating a free, open-source, cheap to deploy content authoring tool. At these times, I found it incredibly motivating to remember who was going to be using the tool and the personal stories that we wanted people to be able to share with it."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/780ccfa0-f11a-11e9-9409-319b90678833.png",
+                        "alternativeText": "a full-screen web design with blue bars on the top and bottom of the screen, a logo of an open book with a heart set into it, and some supporting organization logos at the bottom. The main part of the screen is split vertically in two, with the left side showing some introductory text and the right side showing the block editing interface along with some sample content",
+                        "description": "a more mature design of the storytelling tool along with some framing specific to the Learning Reflections project (outside of the SJRK)",
+                        "fileDetails": {
+                            "lastModified": 1571342670000,
+                            "lastModifiedDate": "2019-10-17T20:04:30.000Z",
+                            "name": "2019-10-17 storytelling tool story - design 3.png",
+                            "size": 232883,
+                            "type": "image/png"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "The development continues, and hopefully some day we will get some outside contributors who can carry on the work and help the tool grow to something more than we could ever imagine."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/780e0820-f11a-11e9-9409-319b90678833.png",
+                        "alternativeText": "a colourful version of the Storytelling Tool with a design that mimics the SJRK website, including the SJRK logo, the same dark blue accent colour and the multicolour confetti background",
+                        "description": "The Storytelling Tool as it looks today",
+                        "fileDetails": {
+                            "lastModified": 1571342677000,
+                            "lastModifiedDate": "2019-10-17T20:04:37.000Z",
+                            "name": "2019-10-17 storytelling tool story - tool 2.png",
+                            "size": 113440,
+                            "type": "image/png"
+                        }
+                    }
+                ],
+                "title": "My SJRK memories",
+                "author": "Gregor",
+                "tags": [
+                    "Memories",
+                    "design",
+                    "development"
+                ]
+            }
+        },
+        "8ea7d380-f03f-11e9-8299-d34aa606fc6a": {
+            "type": "story",
+            "value": {
+                "id": "8ea7d380-f03f-11e9-8299-d34aa606fc6a",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "During the month of May, 8 workshops sponsored by the Karisma Foundation were held within the framework of the Opportunities for Rural Youth project. These workshops were distributed among 3 campuses of the institution; Main campus at Mirella (3 workshops), Las Marias (2 workshops) and Betania (3 workshops)."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "STOP MOTION",
+                        "blockType": "text",
+                        "text": "[![STOP MOTION](https://img.youtube.com/vi/t5rKFK3KC2Q/0.jpg)](https://www.youtube.com/watch?v=t5rKFK3KC2Q)"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Workshop Dynamics",
+                        "blockType": "text",
+                        "text": "The approach to the workshops was the same in each case, while each took a unique shape depending on the skills and interests of the group.\n\nFirst we started with a group presentation in which we shared our name, age, interests and dreams, then, under the inspiration of the projects we talked about the importance of communications and art in the world in which we find ourselves, and how web tools can open doors to embarking on the path of our future.\n\n[![STOP MOTION](https://img.youtube.com/vi/iR6D226g7v8/0.jpg)](https://www.youtube.com/watch?v=iR6D226g7v8)\n\nThe students were asked to write answers to the following questions on a sheet: Who I am? Where do I come from? Where am I going and what is my purpose? The idea was to answer these questions through a video made with the tools provided. The videos were to be posted on the platform under the name of Time Capsule, a project that aims to reinforce the vision that will allow children to develop in all areas of their lives, narrate their experiences, and plan for their future.\n\nSecondly, I shared about my work in The Chronicles of Juana, focusing on the strengths of mobile devices that we usually have at hand and with which we can do almost anything in creative and audiovisual terms.\n\nWithin the framework of these products, key issues arose at all stages of production such as: camera management and the importance of curiosity as the basis for a good photograph, types of plane and angles, interview techniques, body expression and linguistics, the use of music, image rights and authorship, editing work, and others.\n\nIt should be noted that it was not possible to explore all of these issues fully during the course of the 2-hour workshops, given the universe of details that make up a visual work. However, the students were left with a seed which can be germinated to help them find the best way to use the tools to meet their learning and creating needs.\n\n[![STOP MOTION](https://img.youtube.com/vi/4XnYqeYHwu0/0.jpg)](https://www.youtube.com/watch?v=4XnYqeYHwu0)\n\nIn one exercise we used StopMotion, which provides a simple and efficient technique of creation, to make a group animation. This allowed the students to see the ease with which they can carry out our creative ideas, and to live the experience of the world that moves behind the content they are receiving all the time through social networks. In this way they began to understand that they have everything they need to also be content generators.\n\n[![STOP MOTION](https://img.youtube.com/vi/HrlQTm2HFZw/0.jpg)](https://www.youtube.com/watch?v=HrlQTm2HFZw)\n \nTo close the workshop, they shared about creative tools such as FilmoraGo cell phone, MyMovie, Memes Creator, Gift Creator and DuRecorder, with which they have infinite possibilities to let their imagination fly."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Mirella campus",
+                        "blockType": "text",
+                        "text": "On Thursday, May 16, I visited the main campus where I was kindly received at 8:00 am by Professor Giovanna. The first workshop was developed with the 9th grade students, and was based on my experience as a social communicator and journalist, and with the idea of strengthening and reinforcing the student’s creative skills in order to implement them within the framework of a real newscast. The workshop ended at 10:00 am. The second workshop ran from 10:15 am to 12:30 pm with the 8th grade students, and the closing workshop was held with grades 10 and 11 students between 1:00 and 3:30 pm.\n\n[![STOP MOTION](https://img.youtube.com/vi/h3OGP-w6o9g/0.jpg)](https://www.youtube.com/watch?v=h3OGP-w6o9g)\n\nTalents and strengths were identified among some of the students, who expressed interest in the path of communications (mostly YouTubers) as a latent possibility and need for their near futures."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Taller Crearte Comunicativo I",
+                        "blockType": "text",
+                        "text": "[![Taller Crearte Comunicativo I](https://img.youtube.com/vi/nl56d4Re66o/0.jpg)](https://www.youtube.com/watch?v=nl56d4Re66o)\n\nVideo: Audiovisual report of the experience. Example of a report as a recommendation to the real news program on the day."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Las Marías campus",
+                        "blockType": "text",
+                        "text": "After a couple of hours in a jeep ride on an uncovered and rainy road, we arrived around 8:00 am at Las Marías School, where Professor Byron was waiting for us, and led us to a class of 9th grade boys who rose kindly before my arrival as a sign of greeting and respect. The workshop was held until 10:00 am, when the 8th grade boys arrived and with whom we continued until 12:00 pm.\n\n[![STOP MOTION](https://img.youtube.com/vi/-tgHtkV7vdI/0.jpg)](https://www.youtube.com/watch?v=-tgHtkV7vdI)\n\nI can say that the experience with these boys was one of the most inspiring, because their curiosity and willingness allowed the work to flow, such that with a couple of extra hours of meeting in the afternoon we were able to make a short film called \"Freckles\" with everyone's collaboration."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Taller CreArte Comunicativo II. Las Marias",
+                        "blockType": "text",
+                        "text": "[![Taller CreArte Comunicativo II. Las Marias](https://img.youtube.com/vi/4B19EaQKEXA/0.jpg)](https://www.youtube.com/watch?v=4B19EaQKEXA)\n\nVideo: Short film \"Pecas\", about bullying."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Betania campus",
+                        "blockType": "text",
+                        "text": "A sunny day awaited us on the Betania sidewalk, and the workshops with the 8th, 9th and 11th grades were efficiently developed thanks to the collaboration of the boys and especially of Professor Ruth and her daughter, who were kindly active and attentive from the reception to the end of the workshops.\n\n[![STOP MOTION](https://img.youtube.com/vi/hx01EvbhYew/0.jpg)](https://www.youtube.com/watch?v=hx01EvbhYew)\n\nIt was a busy day - together with the boys we applied what they learned and in the afternoon we carried out an activity to recover the historical memory of the district. About 25 boys stayed to give continuity to the process; they held interviews, filmed the spaces, photographed curiosities and in this way explored and applied their new skills.\n\nVideo: Chronicle in Betania, Denunciation of Problems\n\n[![STOP MOTION](https://img.youtube.com/vi/cKw6KEJLPv4/0.jpg)](https://www.youtube.com/watch?v=cKw6KEJLPv4)"
+                    }
+                ],
+                "title": "YOU CREATE, COMMUNICATE Creativity workshop applied to communication.",
+                "author": "",
+                "tags": []
+            }
+        },
+        "98beb190-f107-11e9-9409-319b90678833": {
+            "type": "story",
+            "value": {
+                "id": "98beb190-f107-11e9-9409-319b90678833",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "GUARDIA AMBIENTAL EN EL 2016….",
+                        "blockType": "text",
+                        "text": "En ese momento cuando se inició el proyecto con la guardia ambiental, se encontro una institución en condiciones con deseos y sueños sin desarrollar, que desde sus posibilidades buscaban la manera de lograrlos.\n\nQueríamos llegar a las comunidades y personas que por las condiciones estructurales y de recursos no estaban al alcance para formarse y capacitarse como guardia ambiental. Por ejemplo, era muy difícil formar y capacitar jóvenes en ciudades lejanas de Cartagena y en otros departamentos.\n\nPor esto era importante hacer uso de herramientas tecnológicas que nos facilitaran este fin.\n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "GUARDIA AMBIENTAL COLOMBIANA",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/98b11d00-f107-11e9-9409-319b90678833.jpg",
+                        "alternativeText": "Grupo de Guardianes Ambientales en la ciudad de Cartagena de Indias.",
+                        "description": "Grupo de Guardianes Ambientales en la ciudad de Cartagena de Indias.\nEsta foto fue tomada en el barrio de Canapote el 20 de julio 2015",
+                        "fileDetails": {
+                            "lastModified": 1571327848000,
+                            "lastModifiedDate": "2019-10-17T15:57:28.000Z",
+                            "name": "20157201_1711438219153181_3460593115461091793_o.jpg",
+                            "size": 314497,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "LO QUE LOGRAMOS CON SJRK",
+                        "blockType": "text",
+                        "text": "Queremos contarles lo más importante que hemos construido junto al equipo del proyecto SJRK:\n\nComenzando por decirles que creamos la Pagina Web http://guardiaambiental.org/ con herramientas de visualizacion personalizada que nos ha permitido mostrar lo que hacemos en una gama digital con más influencia y para todas las personas por ser una página accesible.\n\nLa introducción de la herramientas Tecnológicas como los mooc y la visualización de datos ambientales de la ciudad de Cartagena en la Página Web, lo que nos ha permitido ampliar el número de jóvenes interesados y capacitados como Guardias Ambientales que están aportando Gestiones en la recuperación de su entorno.\n\nLa realización de Videos en Cuentalo, una experiencia muy gratificante, porque de esta manera llegamos a conocer historias y vivencias de nuestro jóvenes que por muchos años estaban desarrollando actividades de guardia Ambiental, pero no conocíamos del porqué de su interes y mas aun de toda esas condiciones sociales y familiares a las que habían estado expuestos.\n\nLos talleres de inclusión, que nos enseñaron de qué manera podemos facilitar que todas las personas incluyendo aquellas con discapacidad, desarrollen actividades que recuperen y conserven el medio ambiente.\n\nLa internacionalización de la Guardia Ambiental, a través de la visibilización de las actividades de la Guardia en medios sociales, el intercambios de ideas y experiencias con países como Italia, Brasil, México, las visitas internacionales a la Universidad OCAD Toronto, por parte del Director Roberto Ruiz y el coordinador General de Voluntarios Elbert Rocha y la planificación de un proyecto que permita establecer la Guardia Ambiental en Canadá.\n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/98b27c90-f107-11e9-9409-319b90678833.png",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1571328574000,
+                            "lastModifiedDate": "2019-10-17T16:09:34.000Z",
+                            "name": "Screen Shot 2019-10-17 at 12.09.33 PM.png",
+                            "size": 5322159,
+                            "type": "image/png"
+                        }
+                    }
+                ],
+                "title": "Historia de la participacion de la Guardia Ambiental Colombiana en el proyecto SJRK",
+                "author": "",
+                "tags": [
+                    "Guadia Ambiental",
+                    "SJRK",
+                    "Cartagena"
+                ]
+            }
+        },
+        "999307d0-f123-11e9-9409-319b90678833": {
+            "type": "story",
+            "value": {
+                "id": "999307d0-f123-11e9-9409-319b90678833",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "GUARDIA AMBIENTAL EN EL 2016….",
+                        "blockType": "text",
+                        "text": "En ese momento cuando se inició el proyecto con la guardia ambiental, se encontro una institucion en condiciones con deseos y sueños sin desarrollar, que desde sus posibilidades buscaban la manera de lograrlos.\n\nQueríamos llegar a las comunidades y personas que por las condiciones estructurales y de recursos no estaban al alcance para formarse y capacitarse como guardia ambiental. Por ejemplo, era muy difícil formar y capacitar jóvenes en ciudades lejanas de cartagena y en otros departamentos.\n\nPor esto era importante hacer uso de herramientas tecnológicas que nos facilitaran este fin."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Video de la Guardia Ambiental Colombiana",
+                        "blockType": "text",
+                        "text": "[https://youtu.be/6ugHF1YqNWc](https://youtu.be/6ugHF1YqNWc)"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "LO QUE LOGRAMOS CON SJRK",
+                        "blockType": "text",
+                        "text": "Queremos contarles lo más importante que hemos construido junto al equipo del proyecto SJRK:\n\nComenzando por decirles que creamos la Pagina Web http://guardiaambiental.org/ con herramientas de visualizacion personalizada que nos ha permitido mostrar lo que hacemos en una gama digital con más influencia y para todas las personas por ser una página accesible.\n\nLa introducción de la herramientas Tecnológicas como los mooc y la visualización de datos ambientales de la ciudad de Cartagena en la Página Web, lo que nos ha permitido ampliar el número de jóvenes interesados y capacitados como Guardias Ambientales que están aportando Gestiones en la recuperación de su entorno.\n\nLa realización de Videos en Cuentalo, una experiencia muy gratificante, porque de esta manera llegamos a conocer historias y vivencias de nuestro jóvenes que por muchos años estaban desarrollando actividades de guardia Ambiental, pero no conocíamos del porqué de su interes y mas aun de toda esas condiciones sociales y familiares a las que habían estado expuestos.\n\nLos talleres de inclusión, que nos enseñaron de qué manera podemos facilitar que todas las personas incluyendo aquellas con discapacidad, desarrollen actividades que recuperen y conserven el medio ambiente.\n\nLa internacionalización de la Guardia Ambiental, a través de la visibilización de las actividades de la Guardia en medios sociales, el intercambios de ideas y experiencias con países como Italia, Brasil, México, las visitas internacionales a la Universidad OCAD Toronto, por parte del Director Roberto Ruiz y el coordinador General de Voluntarios Elbert Rocha y la planificación de un proyecto que permita establecer la Guardia Ambiental en Canadá."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Como trabaja la Guardia aAmbiental Colombiana",
+                        "blockType": "text",
+                        "text": "[https://youtu.be/X_Fw2Ud1cms](https://youtu.be/X_Fw2Ud1cms)"
+                    }
+                ],
+                "title": "GUARDIA IN SJRK",
+                "author": "",
+                "tags": []
+            }
+        },
+        "a1956530-f124-11e9-9409-319b90678833": {
+            "type": "story",
+            "value": {
+                "id": "a1956530-f124-11e9-9409-319b90678833",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/a18d4ee0-f124-11e9-9409-319b90678833.jpg",
+                        "alternativeText": "Mural on a school of trees, sun, clouds, birds and a rainbow made of brightly coloiured plastic bottle caps",
+                        "description": "Mural made of bottle caps",
+                        "fileDetails": {
+                            "lastModified": 1571347262000,
+                            "lastModifiedDate": "2019-10-17T21:21:02.000Z",
+                            "name": "1 Mural.jpg",
+                            "size": 554269,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Participating in the Social Justice Repair Kit project was an incredibly rewarding experience. The project showed concretely how much impact we can have on youth in various countries and contexts when we give agency to community groups who are close to and working with youth.\n\nThe ingenuity of the project teams resulted in so many different ideas and implementations - things that worked for particular groups and inspired new ideas for other groups."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "SJRK Resources",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/a18f71c0-f124-11e9-9409-319b90678833.png",
+                        "alternativeText": "Many brightly coloured sticky notes on a red wall. There is writing on the sticky notes but it’s not legible. ",
+                        "description": "Resources created and used by partners in the Social Justice Repair Kit",
+                        "fileDetails": {
+                            "lastModified": 1571347293000,
+                            "lastModifiedDate": "2019-10-17T21:21:33.000Z",
+                            "name": "2 Resources.png",
+                            "size": 1937466,
+                            "type": "image/png"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Just like in a collaborative surprise drawing, we combined our ideas in ways we didn’t plan and the results were unexpected."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Collaborative surprise drawing",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/a1927f00-f124-11e9-9409-319b90678833.jpg",
+                        "alternativeText": "Two drawings of fantastical creatures made collaboratively by the project team.",
+                        "description": "Creatures drawn by the project team without knowing what the whole would look like.",
+                        "fileDetails": {
+                            "lastModified": 1571347323000,
+                            "lastModifiedDate": "2019-10-17T21:22:03.000Z",
+                            "name": "3 Collab.jpg",
+                            "size": 243353,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "When we look at all the work we’ve done for our project, we see the similarities and differences and how the combination of pieces has created a greater whole."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Bee House",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/a1934250-f124-11e9-9409-319b90678833.jpg",
+                        "alternativeText": "A small house shaped structure with sections that are filled with various materials such as tiny bricks, pinecones and sticks where bees can nest.",
+                        "description": "Home for native bees in an organic garden in Colombia",
+                        "fileDetails": {
+                            "lastModified": 1571347349000,
+                            "lastModifiedDate": "2019-10-17T21:22:29.000Z",
+                            "name": "4 Bees.jpg",
+                            "size": 480957,
+                            "type": "image/jpeg"
+                        }
+                    }
+                ],
+                "title": "Ingenuity and Creativity",
+                "author": "Michelle",
+                "tags": []
+            }
+        },
+        "c5613e60-00d5-11ea-addf-fb8afee817da": {
+            "type": "story",
+            "value": {
+                "id": "c5613e60-00d5-11ea-addf-fb8afee817da",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "CONTEXTUALIZATION",
+                        "blockType": "text",
+                        "text": "The city of Cartagena - Colombia, has a population close to 1,036,412 inhabitants according to the projection of municipal population by area developed by the DANE, of which 269,442 are young people between 14 and 28 years old, who represent 26.29% of the general population. We emphasize that the majority of these young people are Afro-descendants and most do not know the levels of realization of their rights, living situations of inequality and social injustice.\n\nIn the Social Justice Repair Kit project, we seek to raise awareness of social diversity in the city of Cartagena through the narration of stories of significant and positive lives of young people living in the city, and in this regard, it was very important to contact youth, youth groups or youth organizations that will develop social, cultural or political activism in the city.\n\nIt was not easy for the project to identify youth organizations or groups that develop a cultural, social or political activism in the city. On the one hand, the government institutions in charge of working with young people did not have a database with the updated information of young people at that time, we had to use the snowball technique based on the information we had of some groups or young people contacted, those who referred us to others and thus managed to contact several of them. This situation gave relevance to the actions developed from the project and think of actions that contribute to remedy that problem .. * the lack of information (timely, truthful, reliable) about youth groups in the city .."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "TELLING THE STORIES",
+                        "blockType": "text",
+                        "text": "The young people who told their stories have situations of social and political inequality in common, and to cope with this they mobilize their own and community resources to promote the guarantee of the rights of the youth in their community. This work, which is not easy, is the product of social fragmentation and polarization manifested by the apathy and indifference of some young people in the face of defending their rights.\n\nTherefore, young people recognize in telling their stories a valuable tool to make known that we are different, recognizing in the other life experiences that allowed them to move forward despite difficulties or problems, being inspiring for other young people.\n\nTo give visibility to the stories from the project, a virtual platform called “cuéntalo.org” was created, enabling timely and reliable data on young people or youth organizations that develop a social activism, making known the type of activity they carry out, population they work with, location among others .."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "LEARNING",
+                        "blockType": "text",
+                        "text": "In the development of the project we learned the importance of the articulation of the different disciplines in the achievement of a common objective and in this case of a social nature ... professionals in audiovisual production, systems engineering, psychology among others we articulate knowledge in the identification, formulation and elaboration of the stories being the young active protagonists and the central axis articulated of the actions…"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Social Justice Repair Kit",
+                        "blockType": "text",
+                        "text": "Presentation of the SJRK team [https://www.youtube.com/watch?v=1fxQqDWaDW8](https://www.youtube.com/watch?v=1fxQqDWaDW8)"
+                    }
+                ],
+                "title": "SJRK CARTAGENA, our story…",
+                "author": "Amaury",
+                "tags": []
+            }
+        },
+        "c7f7a390-f125-11e9-9409-319b90678833": {
+            "type": "story",
+            "value": {
+                "id": "c7f7a390-f125-11e9-9409-319b90678833",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Young people with learning differences in Rwanda are at the margins of society with limited access to education, economic empowerment and livelihood opportunities. The design of programmes such as education trainings, youth economic empowerment and livelihood do not adequately take into consideration the accessibility needs of young people with learning differences in Rwanda. One of the young people who is a 20 year old deaf young woman said that, “Teachers only know basic sign language but cannot explain the concepts in subjects we study in sign language throughout for us to understand”. Another project participant who is a 27 year old female primary six dropout in Musanze district in North of Rwanda said that, “l dropped out in primary school when I was sitting in my PLE in 2007. I did not have a problem with school fees but I was always feeling sick and headache whenever I went back to school because our neighbour bewitched me. I think she bewitched me because i was performing better in class than her children. I passed my exams but the children of our neighbours were not passing exams. I lived with my uncle then but i left home to go and stay with another family”.\n\nOne of the Project participants who is a 20 year old deaf woman living in Kigali city said that, “I want to be helped to acquire Tailoring machines and capital to open up a shop where I can sell my products. Another Project participant who is a 28 year old male participant living in Kabuga said that, “I am in need of support for capital to start buying Poultry, goats and food commodities from villages and sell them in Kigali city and Urban centres”. Another project participant who is a 28 year old participant living in Musanze district,“I want to acquire more skills on how to manage businesses. I want also to get assistance to build a house for my piglets because they are squeezed here”.\n\nThe Social Justice Repair tool kit project interventions in Rwanda focused on working with young people with learning differences to build their capacity to rise their voices for Inclusion in different aspects of life.The project provided an economic empowerment training on how to start and manage a business. Project allocated US$2000 evolving loan to young people with learning differences through UWEZO youth empowerment to start up Saving and loans groups. IDRC also worked with UWEZO youth empowerment on creating and advocating for an enabling environment to facilitate the inclusion of young people with learning differences in different development activities of their communities and country at large. The project donated a Camera and voice recorder to the youth organisation to capture stories and voices of young people with learning differences to advocate for an inclusive environment for all. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/c7f3fa10-f125-11e9-9409-319b90678833.png",
+                        "alternativeText": "The picture shows a group of young people both male and female sitting in a circle listening to one of them presenting to the groups on business ideals.",
+                        "description": "Young people attending a training on how to start and manage a business in Kigali City, Rwanda. ",
+                        "fileDetails": {
+                            "lastModified": 1571347969000,
+                            "lastModifiedDate": "2019-10-17T21:32:49.000Z",
+                            "name": "Rwanda.png",
+                            "size": 870359,
+                            "type": "image/png"
+                        }
+                    }
+                ],
+                "title": "Matching the needs of young people with learning differences with environment in Rwanda",
+                "author": "",
+                "tags": []
+            }
+        },
+        "d827c890-fb42-11e9-addf-fb8afee817da": {
+            "type": "story",
+            "value": {
+                "id": "d827c890-fb42-11e9-addf-fb8afee817da",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "",
+                        "blockType": "text",
+                        "text": "Being involved in the SJRK project has enabled TakingITGlobal to actively explore, pilot and implement accessibility across our programs and operations.\n\nOngoing engagement across the domains of inclusive design, co-design and social justice movements around the world has allowed TIG staff to practise and test the process of inclusive design across new and existing initiatives augmented through our involvement in the project.\n\nThe first and perhaps biggest change across the organization and our work is an overall culture shift which has led to the organization being more comfortable and familiar with the processes involved in inclusion. At first, differences across ability can be challenging to engage with, as there may be an inward fear of offending, of doing or saying the wrong thing. This fear not can prevent us from starting and thus doing anything that could address barriers and advance accommodations for inclusion.\n\nTo ensure our effort in moving towards inclusion was adopted organization wide, we started by examining TIG’s weekly staff meetings and reviewing them from a participation and inclusion perspective. We set up an open process for ongoing feedback and invited our team to participate in the process of iterative improvement, enabling our team to identify and or present topics they would find useful to their work. We also opened a conversation about differences in our learning and the modalities that would be most appropriate for our ongoing professional development. Next we implemented a staff training on the AODA guidelines and created a digital space for onboarding of new staff which integrates accessibility into the welcoming and onboarding process for future staff. TIG’s tech team also benefited from tool specific conversations which enabled us to share tools and practises which result in a more inclusive design and development process.\n\nIn addition to these steps, our team established ongoing support through a recurring “drop in meeting” that allowed staff to discuss their experiences and challenges with accessibility in a more private personal environment. These changes in work culture led to members of the team disclosing their disability status and ongoing discussions about supports we could implement to effectively accommodate these differences. This culture of support also led to new members of the team proactively and publicly discussing their learning differences in staff meetings, addressing stigma and providing useful insights into how we can more effectively work together."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Tech Processes",
+                        "blockType": "text",
+                        "text": "TIG has improved its’ Tech development processes to incorporate new tools which allow us to integrate acessibility into our ongoing design and development work. \n\nTools including the ones below are now integrated into our tech processes, leading to designs that are more usable by people across the spectrum of ability :\n\n* [The Colour Contrast Analyzer](https://developer.paciellogroup.com/resources/contrastanalyser/) - to verify that colour pallets in our designs conform to accessibility best practises\n* [Sim Daltonism](https://michelf.ca/projects/sim-daltonism/) - a colour blindness simulator which allows our designers to see through the eyes of someone with differences in their vision. \n* The [Wave extension](https://wave.webaim.org/extension/) which checks webpages for accessibility elements like ALT text, Aria labels and Headings to ensure our sites will be navigable for individuals across the spectrum of accessibility\n* [Hemmingway](http://www.hemingwayapp.com/) - a webpage which reviews text to ensure it is clear and readable.\n* [Infusion extension](https://fluidproject.org/infusion.html) - a visual accessibility widget that enables websites to be modified to suit the needs of people with visual impairments."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Inclusive Co-design",
+                        "blockType": "text",
+                        "text": "In order to ensure perspectives from people with disabilities are also at the center of our work, TIG engaged with organizations and individuals in the accessibility and disability field. \n\nThrough [RisingYouth](https://risingyouth.ca/), we created collaborations and partnerships with CNIB Newbrunswick and we asked for and incorporated feedback from [Déphy Sans Limite](https://dephy-mtl.org/?news=programmes-dintegration-communautaire) to simplify the language of the federal government grants we are administering. TIG is also actively pursuing regional and national collaborations with further organizations such as CNIB, L’Arche, and BestBuddies. Each of these collaborative conversations ends up leading to iterative changes to our processes in order to meet the diverse needs of the stakeholders involved.\n\nTo develop the [Sustainable Development Goal Inclusive Design Toolkit](https://research.tigweb.org/cristian/sdgid/), TIG contracted Matthew Shapiro from [6WheelsConsulting](https://www.6wheelsconsulting.com/) to provide input and expertise from a disability perspective. Collaborating closely with people with disabilities to implement co-design is a necessary step to ensure their perspectives are at the heart of products and processes built for and about them.\n\nWorking closely in community to identify barriers and determine how to move forward together is an essential facet of social justice. Co-design, collaboration and the sharing of tools and best practises have all benefited the individuals on our team, our organization, the stakeholders of our work and our processes for building a more just and inclusive world together. "
+                    }
+                ],
+                "title": "Implementing Integrated Accessibility",
+                "author": "TakingITGlobal",
+                "tags": [
+                    "inclusive design",
+                    "SJRK"
+                ]
+            }
+        },
+        "df80d2c0-f120-11e9-9409-319b90678833": {
+            "type": "story",
+            "value": {
+                "id": "df80d2c0-f120-11e9-9409-319b90678833",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "In January 2018, the Real Campestre School in Fresno (a small town in the coffee region in Colombia) opened its doors to a new project named: “Oportunidades para jóvenes cafeterxs”. The core of the project is a technological tool, a local network that brings a digital environment into the classroom where students and teachers can upload and share videos, images, text and any kind of digital resources."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Kimera Local Network",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/df0d0250-f120-11e9-9409-319b90678833.png",
+                        "alternativeText": "A diagram of the Kimera Local Network showing the server, the setup of the local network, and the devices of the users",
+                        "description": "Graphic that explains how works the Kimera Local Network",
+                        "fileDetails": {
+                            "lastModified": 1571344104000,
+                            "lastModifiedDate": "2019-10-17T20:28:24.000Z",
+                            "name": "1_red_local_kimera.png",
+                            "size": 229214,
+                            "type": "image/png"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Why is this important?",
+                        "blockType": "text",
+                        "text": "In Fresno, like in many other places in Colombia, connectivity is still a challenge. In the cities, 91 out of 100 schools have Wi-Fi or broadband, but in the countryside, only 53 out of 100 can enjoy this privilege ” (Semana, 2020). "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Institución Educativa Real Campestre",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/df0e13c0-f120-11e9-9409-319b90678833.JPG",
+                        "alternativeText": "A blue and white school entrance. Some people appear in the back of the image. The sky looks white. ",
+                        "description": "Photo of the school entrance.",
+                        "fileDetails": {
+                            "lastModified": 1571344171000,
+                            "lastModifiedDate": "2019-10-17T20:29:31.000Z",
+                            "name": "2_escuela Real Campestre Mireya..JPG",
+                            "size": 2178663,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "A network build of stories!",
+                        "blockType": "text",
+                        "text": "There is not a technological tool that fully works without an appropriation process. “Oportunidades para jóvenes cafeterxs” seek to raise curiosity and the desire to know and learn as well as the willingness to listen and narrate, in order to use the local network as a tool to share those stories and resources that students and teachers find interesting, fun and useful."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Poster Aula Digital Abierta",
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/df125980-f120-11e9-9409-319b90678833.jpg",
+                        "alternativeText": "A poster with a message: “During the last 2 years, Karisma Foundation has been working in the developing of the Kimera Local Network, an alternative that provides access to resources through cell phones, tablets, and computers. Allowing us to improve our “teaching-learning” processes in all courses. Thanks for believing in the Real Campestre School”",
+                        "description": "Photo of a poster with information about the Kimera Local Network.",
+                        "fileDetails": {
+                            "lastModified": 1571344636000,
+                            "lastModifiedDate": "2019-10-17T20:37:16.000Z",
+                            "name": "imageedit_1_7150488559.jpg",
+                            "size": 208231,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "What you want to do?",
+                        "blockType": "text",
+                        "text": "We asked students of Real Campestre to videotaped a short video to introduce themselves. Some of them looked shy in front of the cell phone camera, some spoke too fast, but others looked quite confident. In a diverse group like this, you will find a different reactions and ways to participate in the project.\n\nThe short videos exercises continued during the whole project: it could be understood as a collective album or as the “behind the scenes” of the project."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Presentation Angie Dayana Escobar Ballesteros",
+                        "mediaUrl": "./uploads/df12ceb0-f120-11e9-9409-319b90678833.mp4",
+                        "alternativeText": null,
+                        "description": "A short video presentation of Angie Dayana Escobar, one of the students participating in the project.",
+                        "blockType": "video",
+                        "fileDetails": {
+                            "lastModified": 1571344424000,
+                            "lastModifiedDate": "2019-10-17T20:33:44.000Z",
+                            "name": "BELLEZA.mp4",
+                            "size": 103242093,
+                            "type": "video/mp4"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Everything is happening!",
+                        "blockType": "text",
+                        "text": "In the second year of the project, students want to share all the things that were happening in the school. With the support of some of their teachers, they develop a new idea: a newscast to share the news that take place into their own educational community.\n\nInterviews and reports have been filmed by the students using their own cell phones cameras, a low cost microphone and technical tools like tripods and screens to handle the light are building by the students with recycling materials."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "A newscast in the local network",
+                        "blockType": "text",
+                        "text": "Because connectivity is low or nil in the school, students upload every chapter of the newscast in the local network to be shared with other students or even with their parents when they have access to the network. \n\n“Noticiero Real al día” has 22 videos that are also available on YouTube and Facebook. This initiative has raised new challenges and questions to the students. From what stories they want to share in the news and what technique solutions they need to develop to improve the quality of the image until how they should look and speak in front of the camera.\n\nVisit the youtube channel: \n[https://www.youtube.com/channel/UCwZyE0E5fpLKd607MEJTHiA/videos](https://www.youtube.com/channel/UCwZyE0E5fpLKd607MEJTHiA/videos)"
+                    }
+                ],
+                "title": "From short (very short) videos to a newscast",
+                "author": "",
+                "tags": []
+            }
+        },
+        "ea12d760-f03f-11e9-8299-d34aa606fc6a": {
+            "type": "story",
+            "value": {
+                "id": "ea12d760-f03f-11e9-8299-d34aa606fc6a",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Durante el mes de mayo se realizaron 8 talleres auspiciados por la Fundación Karisma en el marco del proyecto Oportunidades para jóvenes rurales. Estos talleres se distribuyeron entre 3 sedes de la institución; sede principal, Mirella 3 talleres, Las Marias 2 talleres y Betania con 3 talleres."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "STOP MOTION",
+                        "blockType": "text",
+                        "text": "[![STOP MOTION](https://img.youtube.com/vi/t5rKFK3KC2Q/0.jpg)](https://www.youtube.com/watch?v=t5rKFK3KC2Q)"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Dinámica del Taller",
+                        "blockType": "text",
+                        "text": "El taller consiste en una misma formula que va tomando forma dependiendo de las destrezas e intereses de cada grupo.\n\nLo primero, es una presentación grupal en la que compartimos nuestro nombre, edad, gustos y sueños a realizar, seguidamente, bajo la inspiración de los proyectos hablamos de la importancia de las comunicaciones y el arte en el mundo en que nos encontramos y cómo el uso de herramientas web nos permiten la puerta a emprender el camino de nuestro futuro desde hoy.\n\n[![STOP MOTION](https://img.youtube.com/vi/iR6D226g7v8/0.jpg)](https://www.youtube.com/watch?v=iR6D226g7v8)\n\nSe les pide que en una hoja escriban la respuesta a las preguntas; ¿quién soy? ¿de dónde vengo? ¿para dónde voy? y ¿cuál es mi propósito?, con el fin de que contesten a través de un vídeo realizado con las herramientas entregadas. Éste producto se sube a la plataforma bajo el nombre de Cápsula del Tiempo, proyecto que pretende reforzar el horizonte que les permitirá a los chicos desarrollarse en todas las esferas de su vida, narrar su identidad y proyectarse hacia el futuro.\n\nSeguidamente les comparto algo sobre mi trabajo en Las Crónicas de Juana, enfocando las fortalezas de los dispositivos móviles que generalmente tenemos a la mano y con lo cuales podemos realizar casi cualquier cosa en términos creativos y audiovisuales.\n\nDentro del análisis de éstos productos surgen temas claves dentro de la pre, post y producción como: el manejo de la cámara y la importancia de la curiosidad como base de una buena fotografía, tipos de plano y ángulos, la entrevista, la expresión corporal y lingüística, el uso de la música, los derechos de imagen y autoría, trabajo de edición, entre otros.\n\nCabe resaltar que no es posible profundizar acerca de estos temas, pues el tiempo de 2 horas por taller se hace corto entre un universo de detalles que componen una obra visual, sin embargo, se les deja una semilla y en quienes germine, encontrarán en las herramientas entregadas la forma más eficiente de aprender.\n\n[![STOP MOTION](https://img.youtube.com/vi/4XnYqeYHwu0/0.jpg)](https://www.youtube.com/watch?v=4XnYqeYHwu0)\n\nComo ejercicio del taller, tomamos el StopMotion como una de las técnicas de realización más sencilla y eficiente, con la que hacemos una animación grupal, esto les permite a los chicos ver la facilidad con la que podemos llevar a cabo nuestras ideas creativas y llevarse a sus casas la experiencia vivida del mundo que se mueve detrás de los contenidos que todo el tiempo están recibiendo a través de redes sociales y entender que ellos tienen todo para ser también generadores de contenido.\n\n[![STOP MOTION](https://img.youtube.com/vi/HrlQTm2HFZw/0.jpg)](https://www.youtube.com/watch?v=HrlQTm2HFZw)\n \nPara cerrar el taller, se les comparten las herramientas de realización con celular FilmoraGo, MyMovie, Creador de Memes, Creador de Gift y DuRecorder, con las que tienen infinitas posibilidades que ponen a volar su imaginación."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Sede principal. Mirella.",
+                        "blockType": "text",
+                        "text": "El jueves 16 de mayo se visitó la sede principal donde fui amablemente recibida a las 8:00 am por la profesora Giovanna. El primer taller se desarrollo dentro de lo esperado con 9º, nos basamos en mi experiencia como comunicadora social y periodista, pensando también en potenciar las habilidades creativas a reforzar con el fin de implementarlas dentro del marco del Noticiero Real al Día. El taller finalizó alrededor de las 10:00 am. El segundo taller tuvo cabida de 10:15 a 12:30 con el grado 8º y el taller de cierre se realizó con 10º y 11º entre la 1 y las 3:30.\n\n[![STOP MOTION](https://img.youtube.com/vi/h3OGP-w6o9g/0.jpg)](https://www.youtube.com/watch?v=h3OGP-w6o9g)\n\nSe identificaron talentos y fortalezas entre algunos chicos y chicas destacados, quienes dentro de sus intereses consideran el camino de las comunicaciones (en su mayoría youtubers) como una posibilidad y necesidad latente para sus futuros cercanos."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Taller Crearte Comunicativo I",
+                        "blockType": "text",
+                        "text": "[![Taller Crearte Comunicativo I](https://img.youtube.com/vi/nl56d4Re66o/0.jpg)](https://www.youtube.com/watch?v=nl56d4Re66o)\n\nEvidencia: Informe audiovisual de la experiencia. Ejemplo de reportaje como recomendación al proyecto de noticiero Real al Día."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Sede Las Marías.",
+                        "blockType": "text",
+                        "text": "Después de un par de horas de viaje en jeep por un camino destapado y lluvioso, llegamos alrededor de las 8:00 am a la escuela de Las Marías, donde nos esperaba el profesor Byron, quien nos condujo a la clase con los chicos de 9º, quienes se levantaron amablemente ante mi llegada como señal de saludo y respeto. El taller se desarrollo normalmente hasta las 10:00 am, hora en que llegaron los chicos de 8º y con quienes dimos continuidad hasta las 12:00 m.\n\n[![STOP MOTION](https://img.youtube.com/vi/-tgHtkV7vdI/0.jpg)](https://www.youtube.com/watch?v=-tgHtkV7vdI)\n\nPodría decir que la experiencia con estos chicos ha sido una de las más inspiradoras, pues su curiosidad y disposición permitió un trabajo fluido que con un par de horas extra de reunión en la tarde que nos permitió realizar un cortometraje llamdo \"Pecas\" realizado como una colaboración de todos."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Taller CreArte Comunicativo II. Las Marias",
+                        "blockType": "text",
+                        "text": "[![Taller CreArte Comunicativo II. Las Marias](https://img.youtube.com/vi/4B19EaQKEXA/0.jpg)](https://www.youtube.com/watch?v=4B19EaQKEXA)\n\nEvidencia: Cortometraje \"Pecas\", sobre el bullying."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": "Sede Betania.",
+                        "blockType": "text",
+                        "text": "Un día soleado nos aguardaba en la vereda Betania, los talleres con 8º, 9º y 11º, se desarrollaron eficientemente gracias a la colaboración de los chicos y sobre todo de la profesora Ruth y su hija, quienes amablemente estuvieron activas y atentas desde el recibimiento hasta el final de los talleres.\n\n[![STOP MOTION](https://img.youtube.com/vi/hx01EvbhYew/0.jpg)](https://www.youtube.com/watch?v=hx01EvbhYew)\n\nFue un día de bastante trabajo, junto a los chicos aplicamos lo aprendido y en la tarde realizamos una actividad de recuperación de la memoria histórica del corregimiento que los ha visto crecer. Fue así como alrededor de 25 chicos que se quedaron para darle continuidad al proceso, se movieron haciendo entrevistas, filmando los espacios, fotografiando curiosidades y sobre todo explorando sus habilidades.\n\nEvidencia: Crónica en Betania, denuncia de problemática\n\n[![STOP MOTION](https://img.youtube.com/vi/cKw6KEJLPv4/0.jpg)](https://www.youtube.com/watch?v=cKw6KEJLPv4)"
+                    }
+                ],
+                "title": "CREARTE COMUNICATIVO Taller creatividad aplicada a la comunicación.",
+                "author": "",
+                "tags": []
+            }
+        },
+        "eba1c640-f863-11ea-9fdd-552aa35bda8b": {
+            "type": "story",
+            "value": {
+                "id": "eba1c640-f863-11ea-9fdd-552aa35bda8b",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "title": "Jorge's Story",
+                "author": "Jorge Almeida",
+                "tags": [
+                    "family",
+                    "love",
+                    "wheelchair",
+                    "cerebral palsy",
+                    "Portugal",
+                    "Canada",
+                    "respite care",
+                    "Liberator"
+                ],
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 0,
+                        "firstInOrder": true,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb84a150-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "fileDetails": {
+                            "lastModified": 1600286397060,
+                            "name": "Jorge 1.jpg",
+                            "size": 347558,
+                            "type": "image/jpeg"
+                        },
+                        "description": "",
+                        "alternativeText": "A large group of people, including one small child, sit and stand on the grass near some trees. Many are smiling for the camera. They are dressed for warm weather, with many wearing shorts and T-shirts or tank tops."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 1,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb8ba630-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600286432086,
+                            "name": "Jorge 2.jpg",
+                            "size": 196661,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "A young man sits in a wheelchair on some grass in front of a pond surrounded by trees, with a basketball lying on the ground in front of him. He is smiling, and his right arm appears to be in motion. He has short brown hair and wears burgundy track pants, grey socks and a pink and yellow tie-dyed T-shirt."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 2,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb8c9090-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600286447839,
+                            "name": "Jorge 3.jpg",
+                            "size": 226620,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "Two young men in wheelchairs sit side by side at the edge of the street between a small bus and a brick building. They are dressed formally, both wearing ties, with one in a blazer, and are posing and smiling for the camera. In the background there is a man standing beside a wheelchair and an SUV, as well as two people standing on the street directly behind them. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 3,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb8df020-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600286494773,
+                            "name": "Jorge 4.jpg",
+                            "size": 248195,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "A blurry photo shows a young man in a power wheelchair who appears to be moving across a stage. He is beside a table full of trophies, with a number of people sitting behind him on the stage including one woman in a wheelchair."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 4,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb8e8c60-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600286475142,
+                            "name": "Jorge 5.jpg",
+                            "size": 326699,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "A young man sits in a power wheelchair on a stage. A woman stands beside him and appears to be handing him something."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 5,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "heading": "The Early Years",
+                        "text": "Hello. My name is Jorge Almeida. I am 42 years old. I was born December 6th, 1970 in San Joao da Madeira in Portugal. \n\nI come from a family of four: my father, mother, sister and me. I have 11 aunts and uncles and a grandmother still living in Portugal. My mother went into the hospital to have me. The nurse came in too early. She pushed me too much. I was black when I came out. She didn't have air for me. \n\nIn 1971 my parents came to Canada and I lived with my grandmother in Portugal four years while the paper work was being done for me to come to Canada. It was because of my disability that it required more paper work to come to this country. I came to Canada with my grandmother in 1975 when I was 4 years old. We came by airplane. We got off at the wrong place: we got off in Toronto. My family was waiting for us in Montreal. Now I am happy to live here in Canada. \n\nMy mother and father did not know I had Cerebral Palsy when I was a baby. I could not crawl on the floor and I was sick most of the time. We went to the doctor. He said I was slow. He did not want to say what I had."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 6,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb8f9dd0-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600286518724,
+                            "name": "Jorge 6.jpg",
+                            "size": 319357,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "A group of 6 people, including 3 men and 3 women, pose in front of a river under some trees. A bridge appears in the background. One man sits in a wheelchair."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 7,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "heading": "Family Life",
+                        "text": "On Christmas Eve at my house my cousins and my aunt come over. We talk about the last year and after they play bingo we go upstairs to see a movie. At midnight we all stop what we are doing to say \"Merry Christmas!\"\n\nI like living with my family because they help me with many things. I love my family because they talk to me. I am worried because if they die, where would I go? \n\nMy sister is my good friend. She helps me so much with my care.\n\nMy cousin is my good friend because she works at FBA. I can talk with her about my feelings about housing. Sunday is for talking with family and changing air from the city. My family loves going to the park each Sunday in the summer. We go at 8 am. When we get to the park we eat. I watch the men play ball and after my father goes swimming. Father is the cook of the meat. We come back at about 7 pm . When we get back I want to go to bed. We have so much fun each Sunday. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 8,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb908830-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600287263648,
+                            "name": "Jorge 7.jpg",
+                            "size": 324357,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "A group of 4 people pose in front of a large, landscaped garden of grass and flowers. One man and 2 women stand behind a young man sitting in a wheelchair."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 10,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "heading": "Cerebral Palsy",
+                        "text": "When I was born my mother went into the hospital and that is where she went so wrong. My doctor worked all night and after he went home. The nurse wanted to go to sleep after a long night of working. My mother had no pain at that time. The nurse came in to help us too early. When I came out I was all black because there was no air for me. I had the umbilical cord around my neck. That is why I have C.P. \n\nThe nurse put many people in wheelchairs. That makes me so angry. Why wasn't she stopped before that day? I had a friend who was in bed all his life because of her. \n\nI felt so angry because my mother went to the hospital to have a beautiful healthy baby boy. I keep thinking: \" What if my mother had had me at home?\"\n\nI can not walk or talk at all and I am in a wheelchair. It is not that bad; I am happy most of the time. I do have a good life but I do ask why me sometimes. But, if God wanted me in a wheelchair, I make the most of it.\n\nI want to do so many things but I can not do them. I am angry because my little sister can drive a car but I can not. Maybe if I did not have CP I would have been more like my sister. I felt sad when my sister went to play with her friends. \n\nI could have been a cook if I wanted. I learned to cook by watching my mother. She is a good cook when she wants to be. \n\nI get angry when people walk slowly when I am trying to get around them. I get so angry when people cut me off. I feel like saying \"I could not stop my wheelchair, sorry\". When I am in a mall trying to get upstairs or downstairs people do not get off the elevator. I get so angry because they have good legs for the stairs.\n\nThis is what people need to do for me:\n\nI need help with everything. I need help getting up in the morning. I need help to go to the washroom and putting clothing on. I need people to feed me. I need help changing chairs for work. I need a beautiful woman to wash me! I need help with all my care. \n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 9,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb92d220-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600287482251,
+                            "name": "Jorge 8.jpg",
+                            "size": 207774,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "A group of people, including a child and a man in a wheelchair, pose in the sun on a road overlooking what appears to be some water and buildings. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 11,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb934750-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600287790631,
+                            "name": "Jorge 9.jpg",
+                            "size": 149524,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "An autographed polaroid (autograph illegible) showing a young man in a wheelchair being embraced by a woman in a short white dress and high heels, who stands on one foot, while lifting the other leg toward the camera. "
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 12,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "text": "I do not speak so I need a talking machine or a word board to talk.\n\nWhen I was five I had my first Bliss board. My speech therapist Ann made my first board. I liked the board that she made for me. Later on, when I needed a new board I would help her. \n\nThis is how we went about making a Bliss board: We needed to know all the words that I needed for my Bliss board. We had to put all the words and Bliss symbols in their places on the board. If I needed a word and there was no Bliss symbol for that word, we had to make it up. If the word was hamburg we would put bread and meat as one Bliss symbol. We had fun with that. After all the words were in their places, we colored the Bliss board. Here are the colors: people were yellow, feelings were blue, questions and time words were white. There we had a Bliss board!\n\nI did good work. I kept getting 80 or 90 in school. Just think how good I would be if I had \nhad a talking machine that worked back then. I did not answer the teacher much because I was slow to answer. My teacher could not wait for my answer; most days I did not answer a question even if I knew the answer.\n\nMy Talking Computer \t\n\nI once had a talking machine that did not work with my wheelchair, and this went on for two years. I had many therapists who tried to help me but they did not help me all the time. The machine I had would stop so frequently that I was going to the Treatment Centre on average three times a week. I didn't do much work at school such as learning to read because of that faulty machine. I called the therapist at the Treatment Centre so frequently that I felt like sleeping there. The therapist said \"Yes\" it was a good idea to stay there. After fifteen months I told my therapist that I wanted a new machine. \n\nTo sum it up: I was angry and frustrated with the faulty machine because of the many times the therapist and I tried to fix it with no luck. I finally got a new machine called a Light Talker which I had for five years and it never broke. As for my progress in reading, I answered the teacher much more often with this new machine.\n\t\nI have a Liberator now. It has worked well for me so far. I can do so much. I can put in a long talk in my Liberator so I can give a talk. I can print my work on my Liberator too. \n",
+                        "heading": "Talking"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 13,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb939570-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600287989362,
+                            "name": "Jorge 10.jpg",
+                            "size": 219065,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "A close-up view of a communication aid mounted on a wheelchair, showing the input board up top, with large, circular foot controls below, which are labelled with arrows."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 14,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "heading": "Homes",
+                        "text": "I went to the Rotary Home for respite care when I was 11 years old. I didn't like going there much because my friends were not there. I thought to myself \"why don't I go with friends?\". So I did and it made the weekend fun. I loved going there mostly when they made a weekend for teenagers. We went there Friday after school so we could party all weekend. We had fun.\n\nUnfortunately, I could no longer go to the Rotary Home for respite care when I became an adult. The Rotary Home is only for children.\n\nParkway House\n\n#### Adult house\n\nAfter many years of trying to find a house for respite, I think I found a good place. I can go there 12 weeks a year if I want. \n\n If I like the house I will take the 6 weeks. If I like the people that work and live there I will go back.\n\nI tried the house for a week. I was excited and afraid to see what the people were like there. When I got there I needed to do paper work with them. I needed to say all I need help with, for example, how I get out of my wheelchair. I liked that they learned from me. \n\nI loved it at this house because the people who work there are funny. What I like the best is the house is good for my wheelchair and the people that live there are not too loud.\n\n#### My dream house \n\nI would like a home with five adults. My house would work like this: the residents would run the house; we would have a say with everything in that house. We would have meetings about everything. We would choose the people that work for us. I would do the bookkeeping on my computer in my room.\n\nWe would do many things. The weekend would be for us to have fun. I would sleep in on Saturday and Sunday. We would go swimming Saturday afternoon and I would go dancing. I would come home when I want. After all, I would be the boss. \n\nThe house would have rooms for five adults. It would be on one floor with two washrooms.\nWe would live and work like a family. We would make it work so well. My family could live so much more without thinking about me so much. I could live so well. All we need is money to make my dream house work.\n\nI have been working on housing for adults for 6 years now. You may be asking how I do it. I write many letters to all the MPs. What I want to see in Ottawa is a place where adults in wheelchairs can go for respite care. I know this is needed in Ottawa. I will keep working on trying to change things for us all. I want to let people know we need this as soon as possible. Many people will use this place .\n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 15,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "text": "Chantal was my girlfriend. We met at the Treatment Centre when I was 4 years old. We went on trips together to Disney World and Toronto.\n\nChantal and I often went together for respite care at the Rotary Home. We were able to talk together without our families. We both used our voice synthesizers. \n\nOn my 21st birthday, Chantal and I went to the Olive Garden with other friends. We told many funny stories and laughed a lot. When the bus driver picked us up to go home he took Chantal to her family's apartment instead of the Rotary Home. We frantically tried to get across to the bus driver that she was going to the Rotary Home. We laughed all the way back.\n\nUnfortunately, Chantal and I could no longer go to the Rotary Home for respite care when we became adults. The Rotary Home is only for children.\n\nChantal and I also went to work at Computer Wise when we finished McArthur High School.\n \nChantal went for respite at Elizabeth Bruyere on October 31, 1995. She became very sick and she was admitted to the General Hospital. On November 4th she was put on a respirator. Later on, she went into a coma for 6 days and caught pneumonia. \n\nI thought I was not allowed to see her there in ICU. I thought I would try anyway. I was very surprised when they let me in ICU. I talked to her for an hour and I kept going to see her every Wednesday morning. I would tell her about the news at work. I talked about many things. I felt that she could hear me.\n \nI went to see her on a Tuesday. Little did I know that it would be my last time to see her. I was afraid that she might die. Thursday I got to work and got the news that she had died the day before, December 13, 1995. I felt very sad but I was thankful that I had seen her the day before. I had to go to a meeting at Algonquin College Thursday afternoon. I could not think very well because I was so sad.\n \nFriday afternoon I went to her wake. I said my last goodbye to her. I went to her funeral on Saturday. I knew her for most of my life. I miss her.\n",
+                        "heading": "Chantal Bedard"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 16,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb94f500-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600288236860,
+                            "name": "Jorge 11.jpg",
+                            "size": 193738,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "A close-up view of a young woman with dark hair and brown eyes sitting in a chair and smiling with her head tipped back."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 17,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "heading": "Camp Life",
+                        "text": "When I was 5 years old I went to Merrywood Camp for my first time. I didn't like it there much. My mother made me go for many years. \n\nWhen I was 15 years old all that changed. I went with friends and we made camp exciting. We went swimming, boating, fishing and we went on walks. We went outside when we should have been in bed in the afternoon. They tried to find us but we were too quick for them. We did many bad things back then. We put water on a boy we did not like and we put his clothing up a flag pole. One day I was talking with a friend when a staff person came and got me. I went with her but the minute she was not looking I turned my wheelchair around and I went back to where my friends were. My last year I felt sad because I had fun there. \n\nI have been going to the City of Ottawa recreational programs for 20 years. I like it there because they get new staff. The staff have become my good friends. I like it when they say jokes to me. What I like most of all is my talks with them. We talk about what we are doing in life. We do many activities like swimming, going to plays, boating, going to dinner, and much more. \n\nIn July I went to day camp on Thursdays and Fridays. We saw an interesting movie. We went to the Art Gallery: we went to a workshop in the morning and in the afternoon we had questions to answer. How fun that was!\n\nFor the last 6 years I have been going to the March of Dimes camp in the summer. We travel in the bus for 6 hours and we eat in the bus too. I made many new friends. At the camp, we do many things or sit there in the sun if we want. \n\nIn '97 I had fun on my holiday. We had beautiful weather. We got to the camp at 4 pm. I went to see my room and got changed. I met my help for the week and after we went to eat. The meals there are so good. Monday I went on a bus trip around the city and in the afternoon I went for a walk. I went to the farm on Tuesday. I saw many animals and birds. On Tuesday night I went to the casino but I did not win big money.\n\nI was so excited that I could go last year. After all, I hadn't had a holiday like that for two years. It was so much fun. I had many good friends there. I needed a quick holiday right about then. I needed a holiday so bad. \n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 18,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "text": "I went to the doctor one day. My doctor told me he wanted to put a metal rod in my back and I consented. I thought he knew more than I did about this but I was so wrong. I had the operation and I was supposed to be out of the hospital in nine days but I was in the hospital for 6 weeks. If you eat hospital food for 6 long weeks you too would need to see a doctor! \n\nMy right hand moved around without my control and it would remove the tubes on my body. The doctor gave me too much medication to calm me down and I passed out for a while and there were concerns about my well-being. In addition, I battled with pneumonia which probably came about from the lengthy operation and being in the nude. Then I got a large infection where they sewed me up. \n\nFifteen months later when I went to my uncle's place to have supper I felt a sharp pain. I did not think it was the metal rod. I thought the pain would go away quickly. Later I went to the doctor to have an X-Ray and to my surprise I saw that the rod was broken. I went back to the hospital and the doctors fixed it. This time it was much easier on me. \n\nIf it were today I wouldn't have the rod put in. I did not have pain in my back. The doctor said I would have pain later in life. I did not talk to more doctors. That is where I went wrong. I should have talked with more doctors. \n\n\n#### Life in hospital\n\nWhen I was in the Children's Hospital the nurses did not understand me. They did not want to see what I wanted. One day when I was wet, I kept trying to call for help but they did not come. I sat there all wet for many hours. When my worker came to see me she went for help to get me changed. That was not right; they did not stop to see what I needed. I wish they would make a little talking machine for the hospital. \n",
+                        "heading": "My Back Operation"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 19,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "text": "I have an electric wheelchair which I work with my left foot. I have a five-way switch that I use with my left foot to work my wheelchair and my Liberator. \n\nI have a Liberator on my wheelchair so I can tell people where to go. A Liberator is a talking computer. My Liberator is plugged into the back of my electric wheelchair. The Liberator has four levels of words which I can go get with a red light on my Liberator. Ex: Let's say I want the word \"people\". I would go to level one and go get the word \"people\" on my Liberator. I can spell on my Liberator too. \n\nI can write on an IBM computer and that is where I wrote my best seller. My Liberator is plugged into a T-Tam ( Trace Transparent Access Module) which is plugged into an IBM computer. I can do all my writing like that. I can work on the Internet as well.\n\nThat is how I use my Liberator.\n",
+                        "heading": "My Wheelchair and Liberator"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 20,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb956a30-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600288585298,
+                            "name": "Jorge 12.jpg",
+                            "size": 140976,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "Close-up view of someone's foot controlling the large buttons of a communication aid, which are mounted on a foot rest, two of which are visible and are labelled with an up arrow and a right arrow respectively."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 21,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "heading": "The Treatment Centre",
+                        "text": "When I was 4, I started school. My school was at the Treatment Centre beside the Children's Hospital of Eastern Ontario. \n\nI was lucky because I had a good therapist. Her name was Ann Warrick. We tried a talking machine that was a circle with bliss. We made my first bliss board. I would use my thumb to point to words. Thanks to her I can communicate today. \n\nI had two friends and their names were Liz and Chantal. We had lots of fun together. I still keep in contact with Liz today but sadly, Chantal has left this earth. \n \nOur class went on two trips: one was to Disney World for a week and the other was to Toronto for four days. On the first trip, we flew to Disney World and we met with many teenagers in wheelchairs in a park and we ate and played games with them. \n\nOn the second trip, our class went by bus to Toronto and we went to the zoo where we saw many animals.\n\nI was fourteen years old when I went to Centennial School. Bob Watt was my teacher. He worked with me on an Apple 2E. We worked mostly on Logo. I made many things like houses. \n\nI made my name in Logo. I played with my name for months and months to get it right. The day we saw my name on a computer we cried because we were so pleased with my work. \n\nI went to McArthur High School. I had many good friends there. I liked most of my teachers there but there was one teacher I could not stand. She wanted us to be there on time; I was on time most days. One day, I was talking to a teacher's aide about my back when my angry teacher came to get me. I was so angry at her.\n\nI had a bad year that year because my friend Curtis Biggs died a week before Christmas. We were like brothers, he and I. We went to many places with his dad. We went on a fire truck around Ottawa. We kept going on red lights. We went to many 67 games. We had fun when we went to Beavers together.\n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 22,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "text": "My graduation was June 28, 1993. At 5, Kelly and I went from the Rotell to school. We had our graduation at 6. My girlfriend went too. After the graduation, they had drinks for the people that came to see us. We were there for 5 minutes. After all, we had a graduation party to get to. We had a bus to take us to our party. When we got there we ate and after we danced all night long. The meal was good. What I liked most was that my girlfriend Chantal was with me. We danced all night long. We had so much fun that night",
+                        "heading": "My Graduation Night"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 23,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb95b850-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600288796827,
+                            "name": "Jorge 13.jpg",
+                            "size": 326699,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "A young man sits in a power wheelchair on a stage. A woman stands beside him and appears to be handing him something."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 24,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "heading": "SIP",
+                        "text": "One summer I went to the Summer Independence Program in July to learn how to live life independently. The program was at the Rehabilitation Center. I wanted to go to SIP so my doctor said I could go. On June 28 I went to Rotell. We went to see my bedroom and then my mother and I went to the hospital. We had a meeting with my worker and after I said \"See you later\". I went to another meeting to hear about the three weeks.\n\nWe had many meetings about life. We learned many things: cooking with a helper, talking on the telephone and banking. One day the doctor came to talk to us about the birds and the bees. \n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 25,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb967ba0-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600288912795,
+                            "name": "Jorge 14.jpg",
+                            "size": 227116,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "A large group of people pose on an outdoor basketball court, under a basket. Many of them are in wheelchairs in the front row, while others stand behind."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 26,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "text": "I am working four days a week at Computer Wise and I love it. I am working on many jobs. I love that. When I go to work I do not know what jobs I will get. I am learning Word Perfect 7. I write e-mail to send to people and they write back to me. I have a pen pal on the net. I like having a friend that I can write to when I want. \n\nThe job I like the most is writing to many MPs to change things. I wrote so many letters for change with no luck. I will keep after them. When we get what we need I will move on. I hope that day comes soon.\n\nI was excited when I tried the Internet. We had been trying to get me on the net for three months. \n\nI want to learn how to do many more jobs. I want to see what work I can do. The first thing I want to try is bookkeeping. I also want to learn how to write a good CV. I could also work with teenagers who need to learn to use their talking machine. I could ask them questions and they would answer me by using their voice box.\n\nLast but not least, I need to show many people how to drive their wheelchairs. If I did this job I would be working five days a week. I could not come to work at Computer Wise again. Yes - there are that many people who need a driving teacher like me. \n\nWe should get money to pay a person that works for me. Then I could find more work for me to do. I could change where I work or that person could go on outings with me if I wanted.\n",
+                        "heading": "Jobs"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "order": 27,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/eb96c9c0-f863-11ea-9fdd-552aa35bda8b.jpg",
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1600289011515,
+                            "name": "Jorge 15.jpg",
+                            "size": 208699,
+                            "type": "image/jpeg"
+                        },
+                        "alternativeText": "A young man in a wheelchair sits smiling in front of a woman who stands, holding and reading some papers. They appear to be in an office."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 28,
+                        "firstInOrder": false,
+                        "lastInOrder": false,
+                        "blockType": "text",
+                        "heading": "Para",
+                        "text": "We are so lucky to have a bus for people in wheelchairs. We can go everywhere in the city. I must call for a bus the day before. \n\nWhen a person wants to get somewhere on time, most times he or she can but not all the time. Para is good most of the time but they can be late. One day the bus forgot me at work right before my long holiday. I was so angry because I had places to be that day. I was so late. \n\nI wish I could drive. Then I could go where I want when I want. \n"
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "order": 29,
+                        "firstInOrder": false,
+                        "lastInOrder": true,
+                        "blockType": "text",
+                        "heading": "My Dream",
+                        "text": "I dreamt about walking out of my bed one morning. I went to make coffee for my mother and father. They were so surprised that we telephoned my grandma. \n\nI got into my wheelchair to go to work. After ten minutes, I stood up. Everyone at work stared at me with their mouths open. I said, \"Surprise!\". I was so happy. \n"
+                    }
+                ]
+            }
+        },
+        "f378a100-f11f-11e9-9409-319b90678833": {
+            "type": "story",
+            "value": {
+                "id": "f378a100-f11f-11e9-9409-319b90678833",
+                "published": true,
+                "timestampCreated": "2020-11-13T00:00:00.000Z",
+                "timestampPublished": "2020-11-13T00:00:00.000Z",
+                "content": [
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "Matthew and Liam met in summer 2019 at the Global Pathfinders Summit in Virginia. This program was run by the Presidential Precinct to honor the 400th year anniversary of the Virginia General Assembly."
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "image",
+                        "mediaUrl": "./uploads/f3767e20-f11f-11e9-9409-319b90678833.jpg",
+                        "alternativeText": null,
+                        "description": null,
+                        "fileDetails": {
+                            "lastModified": 1571345256000,
+                            "lastModifiedDate": "2019-10-17T20:47:36.000Z",
+                            "name": "IMAG2545.jpg",
+                            "size": 148443,
+                            "type": "image/jpeg"
+                        }
+                    },
+                    {
+                        "id": null,
+                        "language": null,
+                        "heading": null,
+                        "blockType": "text",
+                        "text": "200 people from 50 countries and 25 virginians were brought together to learn and share about democracy, history and the global challenges faced by young people in our world today.\n\nDuring a collaborative dotmocracy activity to develop the Virginia Declarations, Matthew and Liam started to engage based on their shared interests and passions around disability and inclusion. \n\nEquitable democractic practices involves including everyone across the spectrum of perspective and ability, weaving together our diversity into a universal approach that yield better results for everyone.\n\nIncreasing the level of democracy in our society is an inclusive design challenge, as our current political systems are exclusionary and don't necessarily have the resources to bring about the level of inclusion that we need to make our world more fair and equitable. \n\nMoving from where we are to where we want to be on these issues requires effort from all stakeholders, unifying our voices and needs to ensure our social systems represent and respond to our evolving needs.\n\n400 years ago modern representative democracy was founded in Virginia, however to truly modernize our social fabric we need to explore new ways of collecting and meeting the needs of our societies across all our beautiful diversity. \n\nWorking together to solve our problems and designing as a collective process is itself the realization of democratic practice.\n\nHow do we define inclusion and who is not currently being included? These questions represent ongoing and evolving conversations which reflect our understanding of power structures that underpin our lives. To truly advance inclusion and build more equitable societies we need to establish and advance more diverse movements that represent and reflect all differences as a strength.\n\nSocial movements need to be made more available to those populations on the margins, including disability. Social movements are generally not accessible and need to conduct self reflection in order to determine why that is the case and how they can address this. \n\n[https://youtu.be/324XEmqe20g](https://youtu.be/324XEmqe20g)"
+                    }
+                ],
+                "title": "GPS Panorama",
+                "author": "Liam",
+                "tags": [
+                    "GPS"
+                ]
+            }
+        }
+    }
+});

--- a/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/sojustrepairit_stories_0.3.0_to_0.4.0_migration.js
+++ b/src/server/db/migrations/2020-11-13_0.3.0_to_0.4.0/sojustrepairit_stories_0.3.0_to_0.4.0_migration.js
@@ -1,0 +1,68 @@
+/*
+For copyright information, see the AUTHORS.md file in the docs directory of this distribution and at
+https://github.com/fluid-project/sjrk-story-telling/blob/main/docs/AUTHORS.md
+
+Licensed under the New BSD license. You may not use this file except in compliance with this licence.
+You may obtain a copy of the BSD License at
+https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.txt
+*/
+
+// These eslint directives prevent the linter from complaining about the use of
+// globals or arguments that will be prevent in CouchDB design doc functions
+// such as views or validate_doc_update
+
+/* global sjrk, emit, newDoc, oldDoc, userCtx, secObj */
+/*eslint no-unused-vars: ["error", { "vars": "local", "argsIgnorePattern": "newDoc|oldDoc|userCtx|secObj" }]*/
+
+"use strict";
+
+require("infusion");
+fluid.setLogging(true);
+var sjrk = fluid.registerNamespace("sjrk");
+
+require("../../singleNodeConfiguration");
+require("./sojustrepairit_stories_0.3.0_to_0.4.0_documents");
+
+
+// Mix-in grade for all the couch configuration
+// components when actually used to configure
+// the DB
+fluid.defaults("sjrk.storyTelling.server.dbSetup.core", {
+    distributeOptions: [
+        {
+            target: "{that}.options.couchOptions.couchUrl",
+            record: "@expand:kettle.resolvers.env(COUCHDB_URL)"
+        },
+        {
+            target: "{that}.options.components.retryingBehaviour.options.retryOptions.maxRetries",
+            record: "@expand:kettle.resolvers.env(COUCHDB_CONFIG_MAX_RETRIES)"
+        },
+        {
+            target: "{that}.options.components.retryingBehaviour.options.retryOptions.retryDelay",
+            record: "@expand:kettle.resolvers.env(COUCHDB_CONFIG_RETRY_DELAY)"
+        }
+    ],
+    listeners: {
+        "onCreate.configureCouch": "{that}.configureCouch"
+    }
+});
+
+// sets up a new instance of the core setup along with replicatorDb defined
+sjrk.storyTelling.server.replicatorDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with usersDb defined
+sjrk.storyTelling.server.usersDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with globalChangesDb defined
+sjrk.storyTelling.server.globalChangesDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});
+
+// sets up a new instance of the core setup along with the storiesDb defined
+sjrk.storyTelling.server.storiesDb({
+    gradeNames: ["sjrk.storyTelling.server.dbSetup.core"]
+});

--- a/src/server/db/story-dbConfiguration.js
+++ b/src/server/db/story-dbConfiguration.js
@@ -141,12 +141,8 @@ sjrk.storyTelling.server.storiesDb.storyTagsFunction = function (doc) {
  * @param {Object} doc - a document to evaluate in the view
  */
 sjrk.storyTelling.server.storiesDb.storiesByIdFunction = function (doc) {
-    // TODO: this restriction should be reverted to allow only published stories
-    // once the flag is present in all previously-published stories. Please see
-    // SJRK-425 for more info: https://issues.fluidproject.org/browse/SJRK-425
-
-    // only returns published stories or stories that predate the "published" flag
-    if (typeof doc.value.published === "undefined" || doc.value.published) {
+    // only returns published stories
+    if (doc.value.published) {
         var browseDoc = {
             "title": doc.value.title,
             "author": doc.value.author,

--- a/src/server/requestHandlers.js
+++ b/src/server/requestHandlers.js
@@ -117,12 +117,8 @@ sjrk.storyTelling.server.handleGetStory = function (request, dataSource) {
     var noAccessErrorMessage = "An error occurred while retrieving the requested story";
 
     promise.then(function (response) {
-        // TODO: this restriction should be reverted to allow only published stories
-        // once the flag is present in all previously-published stories. Please see
-        // SJRK-425 for more info: https://issues.fluidproject.org/browse/SJRK-425
-
-        // only returns published stories or stories that predate the "published" flag
-        if (typeof response.published === "undefined" || response.published) {
+        // only returns published stories
+        if (response.published) {
             request.events.onSuccess.fire(JSON.stringify(response));
         } else {
             fluid.log(fluid.logLevel.WARN, "Unauthorized: cannot access an unpublished story: " + id);

--- a/tests/server/testServerWithStorage.js
+++ b/tests/server/testServerWithStorage.js
@@ -536,11 +536,9 @@ sjrk.storyTelling.server.testServerWithStorageDefs = [{
     },
     {
         event: "{getSavedPrePublishedStory}.events.onComplete",
-        listener: "sjrk.storyTelling.server.testServerWithStorageDefs.verifyStoryPersistence",
+        listener: "sjrk.storyTelling.server.testServerWithStorageDefs.verifyStoryGetFails",
         args: [
             "{arguments}.0",
-            prePublishedStory,
-            null, // No file expected
             null, // No event needed
             "{that}.configuration.server.options.globalConfig.authoringEnabled"
         ]


### PR DESCRIPTION
This PR restores the previous server/db behaviour of restricting public access to published stories only, and it adds `fluid-couch-config` scripts to "migrate" the data of the production sites from `0.3.0` to `0.4.0`.

Broadly, each script contains the entire data set of its respective site, except it's been massaged to be compliant with the server-side autosave functionality introduced in SJRK-289.

To run the scripts, you must connect to each site's web host container and be situated in the project root directory. From there, run the following commands (one for each site):
| Site name | Command |
| ------------- |-------------|
| [AIHEC](https://aihec.inclusivedesign.ca/storyBrowse.html) | `node .\src\server\db\migrations\2020-11-13_0.3.0_to_0.4.0\aihec_stories_0.3.0_to_0.4.0_migration.js` |
| [Inclusive Cities](https://stories.cities.inclusivedesign.ca/storyBrowse.html) | `node .\src\server\db\migrations\2020-11-13_0.3.0_to_0.4.0\cities_stories_0.3.0_to_0.4.0_migration.js` |
| [FLOE Project](https://stories.floeproject.org/storyBrowse.html) | `node .\src\server\db\migrations\2020-11-13_0.3.0_to_0.4.0\floe_stories_0.3.0_to_0.4.0_migration.js` |
| [Karisma](https://karisma-stories.floeproject.org/storyBrowse.html) | `node .\src\server\db\migrations\2020-11-13_0.3.0_to_0.4.0\karisma_stories_0.3.0_to_0.4.0_migration.js` |
| [SJRK](https://stories.sojustrepairit.org/storyBrowse.html) | `node .\src\server\db\migrations\2020-11-13_0.3.0_to_0.4.0\sojustrepairit_stories_0.3.0_to_0.4.0_migration.js` |