### PR TITLE
SJRK-427 docker: Update to Node 14.15.1 (CVE-2020-8277)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.13.0-alpine
+FROM node:14.15.1-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Newer Docker image that will be available in the next hour or so. I'll re-run the jobs once that happens.