### PR TITLE
SJRK-450: Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "devDependencies": {
         "chance": "1.1.7",
         "eslint-config-fluid": "2.0.0",
-        "eslint-plugin-jsdoc": "31.6.0",
+        "eslint-plugin-jsdoc": "31.6.1",
         "fluid-lint-all": "1.0.4",
         "fluid-pouchdb": "1.0.17",
         "fluid-testem": "2.1.14",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "devDependencies": {
         "chance": "1.1.7",
         "eslint-config-fluid": "2.0.0",
-        "eslint-plugin-jsdoc": "30.7.8",
-        "fluid-lint-all": "1.0.2",
+        "eslint-plugin-jsdoc": "31.6.0",
+        "fluid-lint-all": "1.0.4",
         "fluid-pouchdb": "1.0.17",
         "fluid-testem": "2.1.13",
         "node-jqunit": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -23,21 +23,21 @@
     "homepage": "https://github.com/fluid-project/sjrk-story-telling",
     "dependencies": {
         "express-basic-auth": "1.2.0",
-        "fluid-binder": "1.1.1",
+        "fluid-binder": "1.1.2",
         "fluid-couch-config": "git+https://github.com/BlueSlug/fluid-couch-config.git",
         "fluid-express-user": "2.0.1",
-        "fluid-handlebars": "2.1.3",
-        "fluid-json-schema": "2.1.4",
-        "fluid-location-bar-relay": "1.0.6",
-        "fs-extra": "9.0.1",
+        "fluid-handlebars": "2.1.4",
+        "fluid-json-schema": "2.1.6",
+        "fluid-location-bar-relay": "1.0.7",
+        "fs-extra": "9.1.0",
         "handlebars": "4.7.6",
         "infusion": "3.0.0-dev.20210204T181946Z.3ed160b36.FLUID-6580",
         "jpeg-autorotate": "7.1.1",
         "jpeg-exif": "1.1.4",
         "kettle": "1.15.1",
-        "markdown-it": "12.0.3",
+        "markdown-it": "12.0.4",
         "memorystore": "1.6.4",
-        "uuid": "8.3.1"
+        "uuid": "8.3.2"
     },
     "devDependencies": {
         "chance": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "express-basic-auth": "1.2.0",
         "fluid-binder": "1.1.2",
         "fluid-couch-config": "git+https://github.com/BlueSlug/fluid-couch-config.git",
-        "fluid-express-user": "2.0.1",
+        "fluid-express-user": "2.0.2",
         "fluid-handlebars": "2.1.4",
         "fluid-json-schema": "2.1.6",
         "fluid-location-bar-relay": "1.0.7",
@@ -34,7 +34,7 @@
         "infusion": "3.0.0-dev.20210204T181946Z.3ed160b36.FLUID-6580",
         "jpeg-autorotate": "7.1.1",
         "jpeg-exif": "1.1.4",
-        "kettle": "1.15.1",
+        "kettle": "1.16.0",
         "markdown-it": "12.0.4",
         "memorystore": "1.6.4",
         "uuid": "8.3.2"

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
         "eslint-plugin-jsdoc": "31.6.0",
         "fluid-lint-all": "1.0.4",
         "fluid-pouchdb": "1.0.17",
-        "fluid-testem": "2.1.13",
+        "fluid-testem": "2.1.14",
         "node-jqunit": "1.1.8",
         "nyc": "15.1.0",
         "rimraf": "3.0.2",
-        "sinon": "9.2.1",
+        "sinon": "9.2.4",
         "testem": "3.2.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "fluid-location-bar-relay": "1.0.6",
         "fs-extra": "9.0.1",
         "handlebars": "4.7.6",
-        "infusion": "3.0.0-dev.20200728T104627Z.e6aa1a341.FLUID-6145",
+        "infusion": "3.0.0-dev.20210204T181946Z.3ed160b36.FLUID-6580",
         "jpeg-autorotate": "7.1.1",
         "jpeg-exif": "1.1.4",
         "kettle": "1.15.1",

--- a/sjrk.storyTelling.server.config.json5.example
+++ b/sjrk.storyTelling.server.config.json5.example
@@ -7,27 +7,27 @@
                 "options": {
                     "globalConfig": {
                         /*
-                         * the HTTP port the server will be hosted from, default is 8081
-                         * this only needs to be set if you intend to use a different port
-                         */
+                        * the HTTP port the server will be hosted from, default is 8081
+                        * this only needs to be set if you intend to use a different port
+                        */
                         "port": "8081",
 
                         /*
-                         * the custom theme to load in on top of the base theme
-                         * for the base theme, simply remove, comment out or leave this setting empty
-                         * available themes are: aihec, cities, karisma, learningReflections, sojustrepairit
-                         */
+                        * the custom theme to load in on top of the base theme
+                        * for the base theme, simply remove, comment out or leave this setting empty
+                        * available themes are: aihec, cities, karisma, learningReflections, sojustrepairit
+                        */
                         "theme": "learningReflections",
 
                         /*
-                         * a default file to load at the site root (e.g. index.html)
-                         * if left blank or not set, this will default to storyBrowse.html
-                         */
+                        * a default file to load at the site root (e.g. index.html)
+                        * if left blank or not set, this will default to storyBrowse.html
+                        */
                         "themeIndexFile": "introduction.html",
 
                         /*
-                         * if true, creating and saving stories to the database will be enabled
-                         */
+                        * if true, creating and saving stories to the database will be enabled
+                        */
                         "authoringEnabled": true
                     }
                 }

--- a/src/ui/base-page.js
+++ b/src/ui/base-page.js
@@ -127,7 +127,7 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.
             cookieStore: {
                 type: "fluid.prefs.cookieStore",
                 options: {
-                    gradeNames: ["fluid.dataSource.writable"],
+                    writable: true,
                     cookie: {
                         name: "sjrk-st-settings",
                         path: "/",

--- a/src/ui/ui-storyViewer.js
+++ b/src/ui/ui-storyViewer.js
@@ -130,9 +130,10 @@ https://raw.githubusercontent.com/fluid-project/sjrk-story-telling/main/LICENSE.
         modelRelay: {
             "publishingState": {
                 target: "",
+                source: "publishingState",
                 singleTransform: {
                     type: "fluid.transforms.valueMapper",
-                    defaultInputPath: "publishingState",
+                    defaultInputPath: "",
                     match: {
                         "unpublished": {
                             outputValue: {


### PR DESCRIPTION
Updated to the latest dev release of Infusion from the FLUID-6580 line ( 3.0.0-dev.20210204T181946Z.3ed160b36.FLUID-6580 ). Also updated other dependencies.

_**NOTE:** Could only update to Kettle 1.16.0 as fluid-express-user's latest stable release only supports up to this version of Kettle. There were compatibility issues if I tried to update kettle to the 2.x line. There is a PR ( https://github.com/fluid-project/fluid-express-user/pull/21 ) to address updating fluid-express-user to work with the 2.x line of Kettle._

https://issues.fluidproject.org/browse/SJRK-450