### PR TITLE
SJRK-458 Bump Node.js to v14.16.0 (security release)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.4-alpine
+FROM node:14.16.0-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
https://issues.fluidproject.org/browse/SJRK-458